### PR TITLE
feat: PZ-03 Save user login data

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,32 @@
 import LoginPage from "./pages/LoginPage";
 import AppLayout from "./ui/AppLayout";
+import Span from "./ui/form/Span";
+import { UserCredentials } from "./features/auth/LoginForm";
 
 export default class App {
   appLayout: AppLayout;
 
   constructor() {
     this.appLayout = new AppLayout();
-    this.appLayout.setContent(new LoginPage());
 
     document.body.append(this.appLayout.getElement());
+
+    this.configure();
+  }
+
+  configure() {
+    const userCredentialsString = localStorage.getItem("userCredentials");
+
+    if (userCredentialsString) {
+      // NOTE: it looks like there is no way around typecasting with JSON.parse()
+      const credentials = JSON.parse(userCredentialsString) as UserCredentials;
+
+      // TODO: redirect to start page instead
+      this.appLayout.setContent(
+        new Span("", `Welcome, ${credentials.firstName}`),
+      );
+    } else {
+      this.appLayout.setContent(new LoginPage());
+    }
   }
 }

--- a/src/features/auth/LoginForm.ts
+++ b/src/features/auth/LoginForm.ts
@@ -1,6 +1,12 @@
 import Form, { TextInputParams } from "../../ui/form/Form";
 import { ValidationPatterns } from "../../util/validation";
 
+// NOTE: consider moving this to the separate file, it doesn't really belong here in form component
+export interface UserCredentials {
+  firstName: string;
+  surname: string;
+}
+
 const LOGIN_FORM_FIELDS: Array<TextInputParams> = [
   {
     name: "firstName",
@@ -34,6 +40,26 @@ export default class LoginForm extends Form {
   handleSubmit(e: Event) {
     e.preventDefault();
 
-    this.validateTextInputs();
+    const isValid = this.validateTextInputs();
+
+    if (!isValid) return;
+
+    const credentials = new FormData(this.getElement());
+
+    LoginForm.loginUser(credentials);
+  }
+
+  // NOTE: eslint demands the use of 'this' inside class methods, made it static as a temporal measure
+  // TODO: make it a regular method and navigate to the start page
+  static loginUser(credentials: FormData) {
+    localStorage.setItem(
+      "userCredentials",
+
+      /* TODO: this doesn't look safe enough, 
+      find a way for <UserCredentials> and FormData work together.
+      Ideally, get rid of using localStorage altogether due to safety concerns. 
+      */
+      JSON.stringify(Object.fromEntries(credentials)),
+    );
   }
 }


### PR DESCRIPTION
# What?
The app is now storing the user's first name and surname in the browser's local storage immediately after the submission of the login form.
Closes #4 

# Why?
This functionality enhances user experience by retaining user information for future sessions, even in the absence of a server-side component.

# How?
- Utilized the `localStorage` JavaScript API to store the captured first name and surname.
- Stored the names as separate items or as a single JSON object in local storage.

# Additional note
This solution is adequate for the purposes of this app, but it is not the best option as it is not a secure way to store sensitive information. Please consider a different approach in the future.
