### PR TITLE
chore: Config netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
# What?
Config netlify redirects. Closes #13 

# Why?
Netlify throws 404 error on page reload.

# How?
Created a `netlify.toml` file.