### PR TITLE
Feat: PZ-10 Design game page

### DIFF
--- a/data/words.json
+++ b/data/words.json
@@ -1,0 +1,4145 @@
+{
+  "rounds": [
+    {
+      "levelData": {
+        "id": "1_01",
+        "name": "Stag Hunt",
+        "imageSrc": "level1/deerhunt.jpg",
+        "cutSrc": "level1/cut/deerhunt.jpg",
+        "author": "Niccolò dell'",
+        "year": "1550-52"
+      },
+      "words": [
+        {
+          "audioExample": "files/01_0001_example.mp3",
+          "textExample": "The students agree they have too much homework",
+          "textExampleTranslate": "Студенты согласны, что у них слишком много домашней работы",
+          "id": 1,
+          "word": "agree",
+          "wordTranslate": "согласна"
+        },
+        {
+          "audioExample": "files/01_0003_example.mp3",
+          "textExample": "They arrived at school at 7 a.m",
+          "textExampleTranslate": "Они прибыли в школу в 7 часов утра",
+          "id": 3,
+          "word": "arrive",
+          "wordTranslate": "прибыть"
+        },
+        {
+          "audioExample": "files/01_0004_example.mp3",
+          "textExample": "Is your birthday in August?",
+          "textExampleTranslate": "У тебя день рождения в августе?",
+          "id": 4,
+          "word": "August",
+          "wordTranslate": "август"
+        },
+        {
+          "audioExample": "files/01_0005_example.mp3",
+          "textExample": "There is a small boat on the lake",
+          "textExampleTranslate": "На озере есть маленькая лодка",
+          "id": 5,
+          "word": "boat",
+          "wordTranslate": "лодка"
+        },
+        {
+          "audioExample": "files/01_0006_example.mp3",
+          "textExample": "I ate eggs for breakfast",
+          "textExampleTranslate": "Я ел яйца на завтрак",
+          "id": 6,
+          "word": "breakfast",
+          "wordTranslate": "завтрак"
+        },
+        {
+          "audioExample": "files/01_0007_example.mp3",
+          "textExample": "I brought my camera on my vacation",
+          "textExampleTranslate": "Я принес свою камеру в отпуск",
+          "id": 7,
+          "word": "camera",
+          "wordTranslate": "камера"
+        },
+        {
+          "audioExample": "files/01_0008_example.mp3",
+          "textExample": "The capital of the United States is Washington, D.C",
+          "textExampleTranslate": "Столица Соединенных Штатов - Вашингтон, округ Колумбия",
+          "id": 8,
+          "word": "capital",
+          "wordTranslate": "столица"
+        },
+        {
+          "audioExample": "files/01_0009_example.mp3",
+          "textExample": "Did you catch the ball during the baseball game?",
+          "textExampleTranslate": "Вы поймали мяч во время игры в бейсбол?",
+          "id": 9,
+          "word": "catch",
+          "wordTranslate": "поймать"
+        },
+        {
+          "audioExample": "files/01_0010_example.mp3",
+          "textExample": "People feed ducks at the lake",
+          "textExampleTranslate": "Люди кормят уток у озера",
+          "id": 10,
+          "word": "duck",
+          "wordTranslate": "утка"
+        },
+        {
+          "audioExample": "files/01_0011_example.mp3",
+          "textExample": "The woman enjoys riding her bicycle",
+          "textExampleTranslate": "Женщина любит кататься на велосипеде",
+          "id": 11,
+          "word": "enjoy",
+          "wordTranslate": "наслаждаться"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_02",
+        "name": "Deer beside a Lake",
+        "imageSrc": "level1/deerlake.jpg",
+        "cutSrc": "level1/cut/deerlake.jpg",
+        "author": "Carl Frederik",
+        "year": "1888"
+      },
+      "words": [
+        {
+          "audioExample": "files/01_0012_example.mp3",
+          "textExample": "I will invite my friends to my birthday party",
+          "textExampleTranslate": "Я приглашаю своих друзей на мой день рождения",
+          "id": 12,
+          "word": "invite",
+          "wordTranslate": "пригласить"
+        },
+        {
+          "audioExample": "files/01_0013_example.mp3",
+          "textExample": "I love my family very much",
+          "textExampleTranslate": "Я очень люблю свою семью",
+          "id": 13,
+          "word": "love",
+          "wordTranslate": "любовь"
+        },
+        {
+          "audioExample": "files/01_0014_example.mp3",
+          "textExample": "January is the first month of the year",
+          "textExampleTranslate": "январь - первый месяц года",
+          "id": 14,
+          "word": "month",
+          "wordTranslate": "месяц"
+        },
+        {
+          "audioExample": "files/01_0015_example.mp3",
+          "textExample": "They will travel to Argentina this summer",
+          "textExampleTranslate": "Этим летом они отправятся в Аргентину",
+          "id": 15,
+          "word": "travel",
+          "wordTranslate": "путешествовать"
+        },
+        {
+          "audioExample": "files/01_0016_example.mp3",
+          "textExample": "My typical breakfast is toast and eggs",
+          "textExampleTranslate": "Мой типичный завтрак - тост и яйца",
+          "id": 16,
+          "word": "typical",
+          "wordTranslate": "типичный"
+        },
+        {
+          "audioExample": "files/01_0017_example.mp3",
+          "textExample": "She wants to visit her grandmother",
+          "textExampleTranslate": "Она хочет навестить свою бабушку",
+          "id": 17,
+          "word": "visit",
+          "wordTranslate": "посещение"
+        },
+        {
+          "audioExample": "files/01_0018_example.mp3",
+          "textExample": "Today’s weather is rainy and cloudy",
+          "textExampleTranslate": "Сегодня погода дождливая и облачная",
+          "id": 18,
+          "word": "weather",
+          "wordTranslate": "погода"
+        },
+        {
+          "audioExample": "files/01_0019_example.mp3",
+          "textExample": "What are you doing next week?",
+          "textExampleTranslate": "Что ты делаешь на следующей неделе?",
+          "id": 19,
+          "word": "week",
+          "wordTranslate": "неделя"
+        },
+        {
+          "audioExample": "files/01_0020_example.mp3",
+          "textExample": "The store carried both red and white wine",
+          "textExampleTranslate": "В магазине было красное и белое вино",
+          "id": 20,
+          "word": "wine",
+          "wordTranslate": "вино"
+        },
+        {
+          "audioExample": "files/02_0021_example.mp3",
+          "textExample": "Riding in the rough water was an adventure",
+          "textExampleTranslate": "Езда в бурной воде была приключением",
+          "id": 21,
+          "word": "adventure",
+          "wordTranslate": "приключение"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_03",
+        "name": "Country Road with Cypresses",
+        "imageSrc": "level1/abbati2.jpg",
+        "cutSrc": "level1/cut/abbati2.jpg",
+        "author": "ABBATI, Giuseppe",
+        "year": "1860"
+      },
+      "words": [
+        {
+          "audioExample": "files/02_0022_example.mp3",
+          "textExample": "The boy approached his school",
+          "textExampleTranslate": "Мальчик приблизился к своей школе",
+          "id": 22,
+          "word": "approach",
+          "wordTranslate": "подходить"
+        },
+        {
+          "audioExample": "files/02_0023_example.mp3",
+          "textExample": "The baby carefully climbed down the stairs",
+          "textExampleTranslate": "Малыш осторожно спускался по лестнице",
+          "id": 23,
+          "word": "carefully",
+          "wordTranslate": "внимательно"
+        },
+        {
+          "audioExample": "files/02_0024_example.mp3",
+          "textExample": "The scientist mixed the chemicals",
+          "textExampleTranslate": "Ученый смешал химикаты",
+          "id": 24,
+          "word": "chemical",
+          "wordTranslate": "химический"
+        },
+        {
+          "audioExample": "files/02_0025_example.mp3",
+          "textExample": "She created an igloo from blocks of snow",
+          "textExampleTranslate": "Она создала иглу из снежных глыб",
+          "id": 25,
+          "word": "create",
+          "wordTranslate": "создайте"
+        },
+        {
+          "audioExample": "files/02_0027_example.mp3",
+          "textExample": "The student did an experiment in science class",
+          "textExampleTranslate": "Студент сделал эксперимент в классе науки",
+          "id": 27,
+          "word": "experiment",
+          "wordTranslate": "эксперимент"
+        },
+        {
+          "audioExample": "files/02_0028_example.mp3",
+          "textExample": "I killed the fly",
+          "textExampleTranslate": "Я убил муху",
+          "id": 28,
+          "word": "kill",
+          "wordTranslate": "убийство"
+        },
+        {
+          "audioExample": "files/02_0029_example.mp3",
+          "textExample": "My mother works in a laboratory",
+          "textExampleTranslate": "Моя мама работает в лаборатории",
+          "id": 29,
+          "word": "laboratory",
+          "wordTranslate": "лаборатория"
+        },
+        {
+          "audioExample": "files/02_0030_example.mp3",
+          "textExample": "The sound of her laugh filled the room",
+          "textExampleTranslate": "Звук ее смеха заполнил комнату",
+          "id": 30,
+          "word": "laugh",
+          "wordTranslate": "смех"
+        },
+        {
+          "audioExample": "files/02_0032_example.mp3",
+          "textExample": "The boy became nervous when he heard the news",
+          "textExampleTranslate": "Мальчик стал нервным, когда услышал новости",
+          "id": 32,
+          "word": "nervous",
+          "wordTranslate": "нервная"
+        },
+        {
+          "audioExample": "files/02_0033_example.mp3",
+          "textExample": "The crying baby made a loud noise",
+          "textExampleTranslate": "Плачущий ребенок издал громкий шум",
+          "id": 33,
+          "word": "noise",
+          "wordTranslate": "шум"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_04",
+        "name": "Fireworks in Naples",
+        "imageSrc": "level1/firework.jpg",
+        "cutSrc": "level1/cut/firework.jpg",
+        "author": "ACHENBACH, Oswald",
+        "year": "1875"
+      },
+      "words": [
+        {
+          "audioExample": "files/02_0034_example.mp3",
+          "textExample": "His afternoon work project was to paint the room green",
+          "textExampleTranslate": "Его дневной рабочий проект должен был покрасить комнату в зеленый цвет",
+          "id": 34,
+          "word": "project",
+          "wordTranslate": "проект"
+        },
+        {
+          "audioExample": "files/02_0036_example.mp3",
+          "textExample": "The two boys were sharing a secret",
+          "textExampleTranslate": "Два мальчика делились секретом",
+          "id": 36,
+          "word": "secret",
+          "wordTranslate": "секрет"
+        },
+        {
+          "audioExample": "files/02_0038_example.mp3",
+          "textExample": "The two friends smelled the flower",
+          "textExampleTranslate": "Два друга понюхали цветок",
+          "id": 38,
+          "word": "smell",
+          "wordTranslate": "запах"
+        },
+        {
+          "audioExample": "files/02_0039_example.mp3",
+          "textExample": "The way he treated his classmate was terrible",
+          "textExampleTranslate": "То, как он относился к своему однокласснику, было ужасно",
+          "id": 39,
+          "word": "terrible",
+          "wordTranslate": "ужасный"
+        },
+        {
+          "audioExample": "files/02_0040_example.mp3",
+          "textExample": "Business was worse this month than last month",
+          "textExampleTranslate": "Бизнес был хуже в этом месяце, чем в прошлом месяце",
+          "id": 40,
+          "word": "worse",
+          "wordTranslate": "хуже"
+        },
+        {
+          "audioExample": "files/03_0041_example.mp3",
+          "textExample": "The alien came in peace",
+          "textExampleTranslate": "пришелец пришел с миром",
+          "id": 41,
+          "word": "alien",
+          "wordTranslate": "инопланетянин"
+        },
+        {
+          "audioExample": "files/03_0042_example.mp3",
+          "textExample": "There was a red apple among the green ones",
+          "textExampleTranslate": "Среди зеленых было красное яблоко",
+          "id": 42,
+          "word": "among",
+          "wordTranslate": "среди"
+        },
+        {
+          "audioExample": "files/03_0043_example.mp3",
+          "textExample": "We used a chart to see how we had improved",
+          "textExampleTranslate": "Мы использовали график, чтобы увидеть, как мы улучшили",
+          "id": 43,
+          "word": "chart",
+          "wordTranslate": "диаграмма"
+        },
+        {
+          "audioExample": "files/03_0044_example.mp3",
+          "textExample": "The sky was filled with white clouds",
+          "textExampleTranslate": "Небо было наполнено белыми облаками",
+          "id": 44,
+          "word": "cloud",
+          "wordTranslate": "облако"
+        },
+        {
+          "audioExample": "files/03_0047_example.mp3",
+          "textExample": "Since he failed to get the job, he was sad",
+          "textExampleTranslate": "Так как он не смог получить работу, ему было грустно",
+          "id": 47,
+          "word": "fail",
+          "wordTranslate": "потерпеть поражение"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_05",
+        "name": "The Ninth Wave",
+        "imageSrc": "level1/9th_wave.jpg",
+        "cutSrc": "level1/cut/9th_wave.jpg",
+        "author": "AIVAZOVSKY, Ivan Konstantinovich",
+        "year": "1850"
+      },
+      "words": [
+        {
+          "audioExample": "files/03_0048_example.mp3",
+          "textExample": "I managed to get good grades on my report card",
+          "textExampleTranslate": "Мне удалось получить хорошие оценки на моем табеле",
+          "id": 48,
+          "word": "grade",
+          "wordTranslate": "класс"
+        },
+        {
+          "audioExample": "files/03_0049_example.mp3",
+          "textExample": "He ate the carrot instead of the ice cream",
+          "textExampleTranslate": "Он съел морковку вместо мороженого",
+          "id": 49,
+          "word": "instead",
+          "wordTranslate": "вместо"
+        },
+        {
+          "audioExample": "files/03_0050_example.mp3",
+          "textExample": "The library at school is full of books",
+          "textExampleTranslate": "Библиотека в школе полна книг",
+          "id": 50,
+          "word": "library",
+          "wordTranslate": "библиотека"
+        },
+        {
+          "audioExample": "files/03_0051_example.mp3",
+          "textExample": "I took this photograph with my cell phone",
+          "textExampleTranslate": "Я сделал эту фотографию на свой мобильный",
+          "id": 51,
+          "word": "photograph",
+          "wordTranslate": "фотография"
+        },
+        {
+          "audioExample": "files/03_0052_example.mp3",
+          "textExample": "Saturn is the planet with the ring around it",
+          "textExampleTranslate": "Сатурн - планета с кольцом вокруг него",
+          "id": 52,
+          "word": "planet",
+          "wordTranslate": "планета"
+        },
+        {
+          "audioExample": "files/03_0053_example.mp3",
+          "textExample": "Karen had trouble writing her report",
+          "textExampleTranslate": "Карен не могла написать свой отчет",
+          "id": 53,
+          "word": "report",
+          "wordTranslate": "отчет"
+        },
+        {
+          "audioExample": "files/03_0054_example.mp3",
+          "textExample": "He had to read several books for class",
+          "textExampleTranslate": "Он должен был прочитать несколько книг для класса",
+          "id": 54,
+          "word": "several",
+          "wordTranslate": "несколько"
+        },
+        {
+          "audioExample": "files/03_0056_example.mp3",
+          "textExample": "All the students could easily solve the math problem",
+          "textExampleTranslate": "Все ученики могли легко решить математическую задачу",
+          "id": 56,
+          "word": "solve",
+          "wordTranslate": "решать"
+        },
+        {
+          "audioExample": "files/03_0057_example.mp3",
+          "textExample": "I was surprised when my friends suddenly shouted, “Happy birthday!”",
+          "textExampleTranslate": "Я был удивлен, когда мои друзья вдруг закричали: 'С днем рождения!'",
+          "id": 57,
+          "word": "suddenly",
+          "wordTranslate": "вдруг, внезапно"
+        },
+        {
+          "audioExample": "files/03_0058_example.mp3",
+          "textExample": "I suppose I should go home now",
+          "textExampleTranslate": "Полагаю, мне пора домой",
+          "id": 58,
+          "word": "suppose",
+          "wordTranslate": "предположим"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_06",
+        "name": "View of Campo Santi Giovanni e Paolo",
+        "imageSrc": "level1/campo.jpg",
+        "cutSrc": "level1/cut/campo.jpg",
+        "author": "ALBOTTO, Francesco",
+        "year": "1745"
+      },
+      "words": [
+        {
+          "audioExample": "files/03_0059_example.mp3",
+          "textExample": "Henry could not understand the message",
+          "textExampleTranslate": "Генри не мог понять сообщение",
+          "id": 59,
+          "word": "understand",
+          "wordTranslate": "понимаю"
+        },
+        {
+          "audioExample": "files/03_0060_example.mp3",
+          "textExample": "Michael likes to view himself in the mirror",
+          "textExampleTranslate": "Михаилу нравится видеть себя в зеркале",
+          "id": 60,
+          "word": "view",
+          "wordTranslate": "посмотреть"
+        },
+        {
+          "audioExample": "files/04_0062_example.mp3",
+          "textExample": "Avoid the broken bottle on the floor",
+          "textExampleTranslate": "Избегайте разбитой бутылки на полу",
+          "id": 62,
+          "word": "avoid",
+          "wordTranslate": "избегать"
+        },
+        {
+          "audioExample": "files/04_0063_example.mp3",
+          "textExample": "She always behaves well when her father is around",
+          "textExampleTranslate": "Она всегда ведет себя хорошо, когда ее отец рядом",
+          "id": 63,
+          "word": "behave",
+          "wordTranslate": "вести себя"
+        },
+        {
+          "audioExample": "files/04_0064_example.mp3",
+          "textExample": "A nice warm bath makes me feel so calm",
+          "textExampleTranslate": "Хорошая теплая ванна заставляет меня чувствовать себя так спокойно",
+          "id": 64,
+          "word": "calm",
+          "wordTranslate": "спокойный"
+        },
+        {
+          "audioExample": "files/04_0065_example.mp3",
+          "textExample": "I was filled with concern after reading the newspaper",
+          "textExampleTranslate": "Я был полон беспокойства после прочтения газеты",
+          "id": 65,
+          "word": "concern",
+          "wordTranslate": "беспокойство"
+        },
+        {
+          "audioExample": "files/04_0066_example.mp3",
+          "textExample": "The baby looked very content sitting on the floor",
+          "textExampleTranslate": "Ребенок выглядел очень довольным, сидя на полу",
+          "id": 66,
+          "word": "content",
+          "wordTranslate": "содержание"
+        },
+        {
+          "audioExample": "files/04_0067_example.mp3",
+          "textExample": "I expect the bus to be here very soon",
+          "textExampleTranslate": "Я ожидаю, что автобус будет здесь очень скоро",
+          "id": 67,
+          "word": "expect",
+          "wordTranslate": "ожидать"
+        },
+        {
+          "audioExample": "files/04_0069_example.mp3",
+          "textExample": "Smoking is a bad habit that can kill you",
+          "textExampleTranslate": "Курение - это вредная привычка, которая может тебя убить",
+          "id": 69,
+          "word": "habit",
+          "wordTranslate": "привычка"
+        },
+        {
+          "audioExample": "files/04_0070_example.mp3",
+          "textExample": "My teacher instructs us in several subjects",
+          "textExampleTranslate": "Мой учитель учит нас нескольким предметам",
+          "id": 70,
+          "word": "instruct",
+          "wordTranslate": "инструктирует"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_07",
+        "name": "San Giuseppe di Castello",
+        "imageSrc": "level1/giuseppe.jpg",
+        "cutSrc": "level1/cut/giuseppe.jpg",
+        "author": "ALBOTTO, Francesco",
+        "year": "1745"
+      },
+      "words": [
+        {
+          "audioExample": "files/04_0072_example.mp3",
+          "textExample": "He spent all his money. There is none left",
+          "textExampleTranslate": "Он потратил все свои деньги. Там ничего не осталось",
+          "id": 72,
+          "word": "none",
+          "wordTranslate": "никто"
+        },
+        {
+          "audioExample": "files/04_0076_example.mp3",
+          "textExample": "My lawyer will represent me in court",
+          "textExampleTranslate": "Мой адвокат будет представлять меня в суде",
+          "id": 76,
+          "word": "represent",
+          "wordTranslate": "представлять"
+        },
+        {
+          "audioExample": "files/04_0077_example.mp3",
+          "textExample": "When people shake hands, it usually means they agree",
+          "textExampleTranslate": "Когда люди пожимают друг другу руки, это обычно означает, что они согласны",
+          "id": 77,
+          "word": "shake",
+          "wordTranslate": "трясти"
+        },
+        {
+          "audioExample": "files/04_0078_example.mp3",
+          "textExample": "I like to spread butter on my toast",
+          "textExampleTranslate": "Мне нравится разливать масло по моему тосту",
+          "id": 78,
+          "word": "spread",
+          "wordTranslate": "распространение"
+        },
+        {
+          "audioExample": "files/04_0079_example.mp3",
+          "textExample": "My dog and I strolled through the park today",
+          "textExampleTranslate": "Сегодня мы с собакой прогулялись по парку",
+          "id": 79,
+          "word": "stroll",
+          "wordTranslate": "прогулка"
+        },
+        {
+          "audioExample": "files/04_0080_example.mp3",
+          "textExample": "There are only a few houses in my village",
+          "textExampleTranslate": "В моей деревне всего несколько домов",
+          "id": 80,
+          "word": "village",
+          "wordTranslate": "деревня"
+        },
+        {
+          "audioExample": "files/05_0082_example.mp3",
+          "textExample": "My mom and dad are adults",
+          "textExampleTranslate": "Мои мама и папа взрослые",
+          "id": 82,
+          "word": "adult",
+          "wordTranslate": "взрослый"
+        },
+        {
+          "audioExample": "files/05_0083_example.mp3",
+          "textExample": "She died at the age of 80",
+          "textExampleTranslate": "Она умерла в возрасте 80 лет",
+          "id": 83,
+          "word": "age",
+          "wordTranslate": "возраст"
+        },
+        {
+          "audioExample": "files/05_0084_example.mp3",
+          "textExample": "She is unhappy because she had a bad day",
+          "textExampleTranslate": "Она несчастна, потому что у нее был плохой день",
+          "id": 84,
+          "word": "bad",
+          "wordTranslate": "плохой"
+        },
+        {
+          "audioExample": "files/05_0086_example.mp3",
+          "textExample": "He rides his bike to school every day",
+          "textExampleTranslate": "Он ездит на велосипеде в школу каждый день",
+          "id": 86,
+          "word": "bike",
+          "wordTranslate": "велосипед"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_08",
+        "name": "View of St.Petersburg",
+        "imageSrc": "level1/view_stp.jpg",
+        "cutSrc": "level1/cut/view_stp.jpg",
+        "author": "ALEKSEYEV, Fyodor Yakovlevich",
+        "year": "1795"
+      },
+      "words": [
+        {
+          "audioExample": "files/05_0088_example.mp3",
+          "textExample": "You should go to the doctor when you are sick",
+          "textExampleTranslate": "Вы должны идти к врачу, когда вы больны",
+          "id": 88,
+          "word": "doctor",
+          "wordTranslate": "доктор"
+        },
+        {
+          "audioExample": "files/05_0089_example.mp3",
+          "textExample": "Did you sleep during the movie?",
+          "textExampleTranslate": "Ты спал во время фильма?",
+          "id": 89,
+          "word": "during",
+          "wordTranslate": "в течение"
+        },
+        {
+          "audioExample": "files/05_0090_example.mp3",
+          "textExample": "Football is a popular sport in the United States",
+          "textExampleTranslate": "Футбол - популярный вид спорта в Соединенных Штатах",
+          "id": 90,
+          "word": "football",
+          "wordTranslate": "футбол"
+        },
+        {
+          "audioExample": "files/05_0091_example.mp3",
+          "textExample": "We had a fun time at the birthday party",
+          "textExampleTranslate": "Мы весело провели время на вечеринке по случаю дня рождения",
+          "id": 91,
+          "word": "fun",
+          "wordTranslate": "веселье"
+        },
+        {
+          "audioExample": "files/05_0092_example.mp3",
+          "textExample": "Let’s play a board game tonight",
+          "textExampleTranslate": "Давай поиграем в настольную игру сегодня вечером",
+          "id": 92,
+          "word": "game",
+          "wordTranslate": "игра"
+        },
+        {
+          "audioExample": "files/05_0093_example.mp3",
+          "textExample": "My heart beats fast when I am nervous",
+          "textExampleTranslate": "Мое сердце бьется быстро, когда я нервничаю",
+          "id": 93,
+          "word": "heart",
+          "wordTranslate": "сердце"
+        },
+        {
+          "audioExample": "files/05_0094_example.mp3",
+          "textExample": "People play golf in nice weather",
+          "textExampleTranslate": "Люди играют в гольф в хорошую погоду",
+          "id": 94,
+          "word": "golf",
+          "wordTranslate": "гольф"
+        },
+        {
+          "audioExample": "files/05_0096_example.mp3",
+          "textExample": "My grandfather had a long life",
+          "textExampleTranslate": "У моего деда была долгая жизнь",
+          "id": 96,
+          "word": "life",
+          "wordTranslate": "жизнь"
+        },
+        {
+          "audioExample": "files/05_0097_example.mp3",
+          "textExample": "A marathon is 42.2 kilometers",
+          "textExampleTranslate": "Марафон 42,2 километра",
+          "id": 97,
+          "word": "kilometer",
+          "wordTranslate": "километр"
+        },
+        {
+          "audioExample": "files/05_0098_example.mp3",
+          "textExample": "He often goes to bed early during the week",
+          "textExampleTranslate": "Он часто ложится спать рано в течение недели",
+          "id": 98,
+          "word": "often",
+          "wordTranslate": "довольно часто"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_09",
+        "name": "Landscape with the Finding of Moses",
+        "imageSrc": "level1/landmose.jpg",
+        "cutSrc": "level1/cut/landmose.jpg",
+        "author": "ALLEGRAIN, Etienne",
+        "year": "second half of XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/05_0099_example.mp3",
+          "textExample": "We have plenty of fruit, so help yourself",
+          "textExampleTranslate": "У нас много фруктов, так что помогите себе",
+          "id": 99,
+          "word": "plenty",
+          "wordTranslate": "много"
+        },
+        {
+          "audioExample": "files/05_0100_example.mp3",
+          "textExample": "I gained weight because I ate a lot of pizza",
+          "textExampleTranslate": "Я набрал вес, потому что я ел много пиццы",
+          "id": 100,
+          "word": "weight",
+          "wordTranslate": "вес"
+        },
+        {
+          "audioExample": "files/06_0101_example.mp3",
+          "textExample": "They moved apart and then came back together",
+          "textExampleTranslate": "Они раздвинулись, а затем вернулись вместе",
+          "id": 101,
+          "word": "apart",
+          "wordTranslate": "отдельно"
+        },
+        {
+          "audioExample": "files/06_0104_example.mp3",
+          "textExample": "I was completely wrong",
+          "textExampleTranslate": "Я был совершенно неправ",
+          "id": 104,
+          "word": "completely",
+          "wordTranslate": "полностью"
+        },
+        {
+          "audioExample": "files/06_0107_example.mp3",
+          "textExample": "It is very fashionable to wear a hat",
+          "textExampleTranslate": "Очень модно носить шляпу",
+          "id": 107,
+          "word": "fashionable",
+          "wordTranslate": "модно"
+        },
+        {
+          "audioExample": "files/06_0108_example.mp3",
+          "textExample": "He has travelled widely in foreign countries",
+          "textExampleTranslate": "Он много путешествовал по зарубежным странам",
+          "id": 108,
+          "word": "foreign",
+          "wordTranslate": "иностранные"
+        },
+        {
+          "audioExample": "files/06_0110_example.mp3",
+          "textExample": "He used the mirror to shine light in their eyes",
+          "textExampleTranslate": "Он использовал зеркало, чтобы светить им в глаза",
+          "id": 110,
+          "word": "mirror",
+          "wordTranslate": "зеркало"
+        },
+        {
+          "audioExample": "files/06_0111_example.mp3",
+          "textExample": "We need to take care of the natural world",
+          "textExampleTranslate": "Нам нужно заботиться о мире природы",
+          "id": 111,
+          "word": "natural",
+          "wordTranslate": "естественный"
+        },
+        {
+          "audioExample": "files/06_0112_example.mp3",
+          "textExample": "Nowadays, not so many people smoke",
+          "textExampleTranslate": "В настоящее время не так много людей курят",
+          "id": 112,
+          "word": "nowadays",
+          "wordTranslate": "в наше время"
+        },
+        {
+          "audioExample": "files/06_0113_example.mp3",
+          "textExample": "There were thousands of participants in this year’s marathon",
+          "textExampleTranslate": "В этом году в марафоне приняли участие тысячи человек",
+          "id": 113,
+          "word": "participant",
+          "wordTranslate": "участник"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_10",
+        "name": "River Landscape",
+        "imageSrc": "level1/riverla2.jpg",
+        "cutSrc": "level1/cut/riverla2.jpg",
+        "author": "ALLEGRAIN, Etienne",
+        "year": "second half of XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/06_0115_example.mp3",
+          "textExample": "We cannot take back what has been spoken",
+          "textExampleTranslate": "Мы не можем забрать то, что было сказано",
+          "id": 115,
+          "word": "spoken",
+          "wordTranslate": "знание"
+        },
+        {
+          "audioExample": "files/06_0116_example.mp3",
+          "textExample": "She loves watching sport on TV",
+          "textExampleTranslate": "Она любит смотреть спорт по телевизору",
+          "id": 116,
+          "word": "sport",
+          "wordTranslate": "спорт"
+        },
+        {
+          "audioExample": "files/06_0119_example.mp3",
+          "textExample": "I am totally against that",
+          "textExampleTranslate": "Я полностью против этого",
+          "id": 119,
+          "word": "totally",
+          "wordTranslate": "полностью"
+        },
+        {
+          "audioExample": "files/07_0121_example.mp3",
+          "textExample": "Having a ticket will allow you to enter the show",
+          "textExampleTranslate": "Наличие билета позволит вам войти в шоу",
+          "id": 121,
+          "word": "allow",
+          "wordTranslate": "позволять"
+        },
+        {
+          "audioExample": "files/07_0122_example.mp3",
+          "textExample": "He announced to everyone his new idea for the company",
+          "textExampleTranslate": "Он объявил всем свою новую идею для компании",
+          "id": 122,
+          "word": "announce",
+          "wordTranslate": "объявить"
+        },
+        {
+          "audioExample": "files/07_0123_example.mp3",
+          "textExample": "The two brothers stood beside each other",
+          "textExampleTranslate": "Два брата стояли рядом друг с другом",
+          "id": 123,
+          "word": "beside",
+          "wordTranslate": "ряд"
+        },
+        {
+          "audioExample": "files/07_0125_example.mp3",
+          "textExample": "He claimed to know why the country’s laws were weak",
+          "textExampleTranslate": "Он утверждал, что знает, почему законы страны были слабыми",
+          "id": 125,
+          "word": "claim",
+          "wordTranslate": "запрос"
+        },
+        {
+          "audioExample": "files/07_0126_example.mp3",
+          "textExample": "The patient’s condition was very good",
+          "textExampleTranslate": "Состояние пациента было очень хорошим",
+          "id": 126,
+          "word": "condition",
+          "wordTranslate": "состояние"
+        },
+        {
+          "audioExample": "files/07_0127_example.mp3",
+          "textExample": "We decided to contribute money to the new hospital",
+          "textExampleTranslate": "Мы решили внести деньги в новую больницу",
+          "id": 127,
+          "word": "contribute",
+          "wordTranslate": "делать вклад"
+        },
+        {
+          "audioExample": "files/07_0129_example.mp3",
+          "textExample": "We divided the pizza",
+          "textExampleTranslate": "Мы разделили пиццу",
+          "id": 129,
+          "word": "divide",
+          "wordTranslate": "делить"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_11",
+        "name": "Extensive Wooded Landscape with Cephalus and Procris",
+        "imageSrc": "level1/extensiv.jpg",
+        "cutSrc": "level1/cut/extensiv.jpg",
+        "author": "ALSLOOT, Denis van",
+        "year": "first half of XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/07_0130_example.mp3",
+          "textExample": "The wizard was an expert at magic",
+          "textExampleTranslate": "Волшебник был экспертом в магии",
+          "id": 130,
+          "word": "expert",
+          "wordTranslate": "эксперт"
+        },
+        {
+          "audioExample": "files/07_0131_example.mp3",
+          "textExample": "The Eiffel Tower in Paris is very famous",
+          "textExampleTranslate": "Эйфелева башня в Париже очень известна",
+          "id": 131,
+          "word": "famous",
+          "wordTranslate": "известный"
+        },
+        {
+          "audioExample": "files/07_0134_example.mp3",
+          "textExample": "Don’t lay your socks on the floor",
+          "textExampleTranslate": "Не кладите носки на пол",
+          "id": 134,
+          "word": "lay",
+          "wordTranslate": "лежал"
+        },
+        {
+          "audioExample": "files/07_0135_example.mp3",
+          "textExample": "A white dove is a symbol of peace",
+          "textExampleTranslate": "Белый голубь - символ мира",
+          "id": 135,
+          "word": "peace",
+          "wordTranslate": "мир"
+        },
+        {
+          "audioExample": "files/07_0136_example.mp3",
+          "textExample": "The prince and the princess were married",
+          "textExampleTranslate": "Принц и принцесса были женаты",
+          "id": 136,
+          "word": "prince",
+          "wordTranslate": "принц"
+        },
+        {
+          "audioExample": "files/07_0137_example.mp3",
+          "textExample": "Firemen protect us from fires",
+          "textExampleTranslate": "Пожарные защищают нас от пожаров",
+          "id": 137,
+          "word": "protect",
+          "wordTranslate": "защита"
+        },
+        {
+          "audioExample": "files/07_0138_example.mp3",
+          "textExample": "I could sense that he was watching me",
+          "textExampleTranslate": "Я чувствовал, что он смотрит на меня",
+          "id": 138,
+          "word": "sense",
+          "wordTranslate": "смысл"
+        },
+        {
+          "audioExample": "files/07_0139_example.mp3",
+          "textExample": "He felt a sudden pain in his chest",
+          "textExampleTranslate": "Он почувствовал внезапную боль в груди",
+          "id": 139,
+          "word": "sudden",
+          "wordTranslate": "внезапное"
+        },
+        {
+          "audioExample": "files/07_0140_example.mp3",
+          "textExample": "He is fat. Therefore, he should go on a diet",
+          "textExampleTranslate": "Он толстый. Поэтому ему следует сесть на диету",
+          "id": 140,
+          "word": "therefore",
+          "wordTranslate": "следовательно"
+        },
+        {
+          "audioExample": "files/08_0141_example.mp3",
+          "textExample": "I accepted the girl’s very nice gift",
+          "textExampleTranslate": "Я принял очень хороший подарок девушки",
+          "id": 141,
+          "word": "accept",
+          "wordTranslate": "принять"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_12",
+        "name": "Skating during Carnival",
+        "imageSrc": "level1/skating.jpg",
+        "cutSrc": "level1/cut/skating.jpg",
+        "author": "ALSLOOT, Denis van",
+        "year": "1620"
+      },
+      "words": [
+        {
+          "audioExample": "files/08_0142_example.mp3",
+          "textExample": "Please arrange the words in order from A to Z",
+          "textExampleTranslate": "Пожалуйста, расположите слова в порядке от А до Я",
+          "id": 142,
+          "word": "arrange",
+          "wordTranslate": "организовать"
+        },
+        {
+          "audioExample": "files/08_0143_example.mp3",
+          "textExample": "My sister and I attend the same school",
+          "textExampleTranslate": "Мы с сестрой учимся в одной школе",
+          "id": 143,
+          "word": "attend",
+          "wordTranslate": "присутствовать"
+        },
+        {
+          "audioExample": "files/08_0144_example.mp3",
+          "textExample": "I was chased by a dog",
+          "textExampleTranslate": "Меня преследовала собака",
+          "id": 144,
+          "word": "chase",
+          "wordTranslate": "гнаться"
+        },
+        {
+          "audioExample": "files/08_0145_example.mp3",
+          "textExample": "The contrast between my parents is very noticeable",
+          "textExampleTranslate": "Контраст между моими родителями очень заметен",
+          "id": 145,
+          "word": "contrast",
+          "wordTranslate": "контраст"
+        },
+        {
+          "audioExample": "files/08_0146_example.mp3",
+          "textExample": "My football coach will encourage us when we are losing",
+          "textExampleTranslate": "Мой футбольный тренер будет воодушевлять нас, когда мы проигрываем",
+          "id": 146,
+          "word": "encourage",
+          "wordTranslate": "поощрять"
+        },
+        {
+          "audioExample": "files/08_0147_example.mp3",
+          "textExample": "The two friends were very familiar with each other",
+          "textExampleTranslate": "Два друга были очень знакомы друг с другом",
+          "id": 147,
+          "word": "familiar",
+          "wordTranslate": "знакомые"
+        },
+        {
+          "audioExample": "files/08_0148_example.mp3",
+          "textExample": "I grabbed a pear from the tree",
+          "textExampleTranslate": "Я схватил грушу с дерева",
+          "id": 148,
+          "word": "grab",
+          "wordTranslate": "захват"
+        },
+        {
+          "audioExample": "files/08_0150_example.mp3",
+          "textExample": "At work, my father drives a huge truck",
+          "textExampleTranslate": "На работе мой отец водит огромный грузовик",
+          "id": 150,
+          "word": "huge",
+          "wordTranslate": "огромный"
+        },
+        {
+          "audioExample": "files/08_0151_example.mp3",
+          "textExample": "A passport is necessary if you travel to other countries",
+          "textExampleTranslate": "Паспорт необходим, если вы путешествуете в другие страны",
+          "id": 151,
+          "word": "necessary",
+          "wordTranslate": "нужно"
+        },
+        {
+          "audioExample": "files/08_0154_example.mp3",
+          "textExample": "The purpose of exercising is to get into shape",
+          "textExampleTranslate": "Цель упражнений - прийти в форму",
+          "id": 154,
+          "word": "purpose",
+          "wordTranslate": "цель"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_13",
+        "name": "Winter Landscape",
+        "imageSrc": "level1/winter_l.jpg",
+        "cutSrc": "level1/cut/winter_l.jpg",
+        "author": "ALSLOOT, Denis van",
+        "year": "1610"
+      },
+      "words": [
+        {
+          "audioExample": "files/08_0155_example.mp3",
+          "textExample": "She released the bird from her hands",
+          "textExampleTranslate": "Она выпустила птицу из рук",
+          "id": 155,
+          "word": "release",
+          "wordTranslate": "релиз"
+        },
+        {
+          "audioExample": "files/08_0156_example.mp3",
+          "textExample": "We require teachers to have a university degree",
+          "textExampleTranslate": "Мы требуем, чтобы преподаватели имели высшее образование",
+          "id": 156,
+          "word": "require",
+          "wordTranslate": "требуют"
+        },
+        {
+          "audioExample": "files/08_0157_example.mp3",
+          "textExample": "I am very satisfied with your work",
+          "textExampleTranslate": "Я очень доволен вашей работой",
+          "id": 157,
+          "word": "satisfied",
+          "wordTranslate": "доволен"
+        },
+        {
+          "audioExample": "files/08_0158_example.mp3",
+          "textExample": "I have a single key in my hand",
+          "textExampleTranslate": "У меня в руке один ключ",
+          "id": 158,
+          "word": "single",
+          "wordTranslate": "один"
+        },
+        {
+          "audioExample": "files/08_0159_example.mp3",
+          "textExample": "It is easy to tear paper",
+          "textExampleTranslate": "Бумагу легко порвать",
+          "id": 159,
+          "word": "tear",
+          "wordTranslate": "слеза"
+        },
+        {
+          "audioExample": "files/08_0160_example.mp3",
+          "textExample": "We talked about Einstein’s theory of relativity in class",
+          "textExampleTranslate": "Мы говорили о теории относительности Эйнштейна в классе",
+          "id": 160,
+          "word": "theory",
+          "wordTranslate": "теория"
+        },
+        {
+          "audioExample": "files/09_0161_example.mp3",
+          "textExample": "My favorite animal is the panda",
+          "textExampleTranslate": "Мое любимое животное - панда",
+          "id": 161,
+          "word": "animal",
+          "wordTranslate": "животное"
+        },
+        {
+          "audioExample": "files/09_0162_example.mp3",
+          "textExample": "My father takes the bus to work",
+          "textExampleTranslate": "Мой отец садится на автобус на работу",
+          "id": 162,
+          "word": "bus",
+          "wordTranslate": "автобус"
+        },
+        {
+          "audioExample": "files/09_0163_example.mp3",
+          "textExample": "This cat is playing with a ball",
+          "textExampleTranslate": "Этот кот играет с мячом",
+          "id": 163,
+          "word": "cat",
+          "wordTranslate": "кошка"
+        },
+        {
+          "audioExample": "files/09_0164_example.mp3",
+          "textExample": "Joe gave the students a command to stand up",
+          "textExampleTranslate": "Джо дал студентам команду встать",
+          "id": 164,
+          "word": "command",
+          "wordTranslate": "команда"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_14",
+        "name": "Winter Landscape in the Fôret de Soignes, with the Flight Into Egypt",
+        "imageSrc": "level1/winterla.jpg",
+        "cutSrc": "level1/cut/winterla.jpg",
+        "author": "ALSLOOT, Denis van",
+        "year": "1616"
+      },
+      "words": [
+        {
+          "audioExample": "files/09_0165_example.mp3",
+          "textExample": "My grandfather depends on a cane when he walks",
+          "textExampleTranslate": "Мой дедушка зависит от трости, когда он гуляет",
+          "id": 165,
+          "word": "depend",
+          "wordTranslate": "зависит"
+        },
+        {
+          "audioExample": "files/09_0166_example.mp3",
+          "textExample": "This woman’s best friend is her dog",
+          "textExampleTranslate": "Лучший друг этой женщины - ее собака",
+          "id": 166,
+          "word": "dog",
+          "wordTranslate": "собака"
+        },
+        {
+          "audioExample": "files/09_0167_example.mp3",
+          "textExample": "Can you close the door, please?",
+          "textExampleTranslate": "Можете ли вы закрыть дверь, пожалуйста?",
+          "id": 167,
+          "word": "door",
+          "wordTranslate": "дверь"
+        },
+        {
+          "audioExample": "files/09_0168_example.mp3",
+          "textExample": "Brian’s friend is very sad",
+          "textExampleTranslate": "Друг Брайана очень грустный",
+          "id": 168,
+          "word": "friend",
+          "wordTranslate": "друг"
+        },
+        {
+          "audioExample": "files/09_0169_example.mp3",
+          "textExample": "Michelle cannot hear what you are saying",
+          "textExampleTranslate": "Мишель не слышит, что ты говоришь",
+          "id": 169,
+          "word": "hear",
+          "wordTranslate": "слышать"
+        },
+        {
+          "audioExample": "files/09_0170_example.mp3",
+          "textExample": "Jane can help Nathan climb up the rock",
+          "textExampleTranslate": "Джейн может помочь Натану взобраться на скалу",
+          "id": 170,
+          "word": "help",
+          "wordTranslate": "помогите"
+        },
+        {
+          "audioExample": "files/09_0171_example.mp3",
+          "textExample": "I went to a farm and saw a horse",
+          "textExampleTranslate": "Я пошел на ферму и увидел лошадь",
+          "id": 171,
+          "word": "horse",
+          "wordTranslate": "лошадь"
+        },
+        {
+          "audioExample": "files/09_0172_example.mp3",
+          "textExample": "The doctor talks to a patient at the hospital",
+          "textExampleTranslate": "Доктор разговаривает с пациентом в больнице",
+          "id": 172,
+          "word": "hospital",
+          "wordTranslate": "больница"
+        },
+        {
+          "audioExample": "files/09_0173_example.mp3",
+          "textExample": "She hurt her leg",
+          "textExampleTranslate": "Она повредила ногу",
+          "id": 173,
+          "word": "leg",
+          "wordTranslate": "нога"
+        },
+        {
+          "audioExample": "files/09_0174_example.mp3",
+          "textExample": "Tyler is a medical student studying to become a doctor",
+          "textExampleTranslate": "Тайлер студент-медик учится на доктора",
+          "id": 174,
+          "word": "medical",
+          "wordTranslate": "медицинский"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_15",
+        "name": "View of Vienna from the Prater",
+        "imageSrc": "level1/viewvien.jpg",
+        "cutSrc": "level1/cut/viewvien.jpg",
+        "author": "ALT, Rudolf von",
+        "year": "1834"
+      },
+      "words": [
+        {
+          "audioExample": "files/09_0176_example.mp3",
+          "textExample": "The children pull the rope",
+          "textExampleTranslate": "Дети тянут веревку",
+          "id": 176,
+          "word": "pull",
+          "wordTranslate": "вытащить"
+        },
+        {
+          "audioExample": "files/09_0177_example.mp3",
+          "textExample": "Look at the rabbit in the park",
+          "textExampleTranslate": "Посмотри на кролика в парке",
+          "id": 177,
+          "word": "rabbit",
+          "wordTranslate": "кролик"
+        },
+        {
+          "audioExample": "files/09_0178_example.mp3",
+          "textExample": "The students study at school",
+          "textExampleTranslate": "Ученики учатся в школе",
+          "id": 178,
+          "word": "school",
+          "wordTranslate": "школа"
+        },
+        {
+          "audioExample": "files/09_0179_example.mp3",
+          "textExample": "Steven does not want to see the scary picture",
+          "textExampleTranslate": "Стивен не хочет видеть страшную картину",
+          "id": 179,
+          "word": "see",
+          "wordTranslate": "видеть"
+        },
+        {
+          "audioExample": "files/09_0180_example.mp3",
+          "textExample": "This coffee shop has excellent service",
+          "textExampleTranslate": "В этой кофейне отличный сервис",
+          "id": 180,
+          "word": "service",
+          "wordTranslate": "служба"
+        },
+        {
+          "audioExample": "files/10_0181_example.mp3",
+          "textExample": "Being able to fly is a benefit to birds",
+          "textExampleTranslate": "Умение летать приносит пользу птицам",
+          "id": 181,
+          "word": "benefit",
+          "wordTranslate": "выгода"
+        },
+        {
+          "audioExample": "files/10_0182_example.mp3",
+          "textExample": "I am certain that zebras have stripes",
+          "textExampleTranslate": "Я уверен, что у зебр есть полоски",
+          "id": 182,
+          "word": "certain",
+          "wordTranslate": "определенный"
+        },
+        {
+          "audioExample": "files/10_0184_example.mp3",
+          "textExample": "The medicine had a good effect on the boy",
+          "textExampleTranslate": "Лекарство оказало хорошее влияние на мальчика",
+          "id": 184,
+          "word": "effect",
+          "wordTranslate": "эффект"
+        },
+        {
+          "audioExample": "files/10_0185_example.mp3",
+          "textExample": "It is essential to have oxygen when you scuba dive",
+          "textExampleTranslate": "Крайне важно иметь кислород, когда вы погружаетесь с аквалангом",
+          "id": 185,
+          "word": "essential",
+          "wordTranslate": "существенный"
+        },
+        {
+          "audioExample": "files/10_0189_example.mp3",
+          "textExample": "The grass looked so soft and green",
+          "textExampleTranslate": "Трава выглядела такой мягкой и зеленой",
+          "id": 189,
+          "word": "grass",
+          "wordTranslate": "трава"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_16",
+        "name": "An English 3rd - Rate Ship of the Line in Three Positions",
+        "imageSrc": "level1/rateship.jpg",
+        "cutSrc": "level1/cut/rateship.jpg",
+        "author": "ANDERSON, William",
+        "year": "first half of XIX century"
+      },
+      "words": [
+        {
+          "audioExample": "files/10_0190_example.mp3",
+          "textExample": "The police officer will guard us from any harm",
+          "textExampleTranslate": "Полицейский будет охранять нас от любого вреда",
+          "id": 190,
+          "word": "guard",
+          "wordTranslate": "охранник"
+        },
+        {
+          "audioExample": "files/10_0191_example.mp3",
+          "textExample": "The image of her eye was very clear",
+          "textExampleTranslate": "Образ ее глаза был очень четким",
+          "id": 191,
+          "word": "image",
+          "wordTranslate": "образ"
+        },
+        {
+          "audioExample": "files/10_0192_example.mp3",
+          "textExample": "An immediate response came from the pizza place",
+          "textExampleTranslate": "Немедленный ответ пришел из пиццерии",
+          "id": 192,
+          "word": "immediate",
+          "wordTranslate": "немедленно"
+        },
+        {
+          "audioExample": "files/10_0193_example.mp3",
+          "textExample": "His primary thoughts are about money",
+          "textExampleTranslate": "Его главные мысли о деньгах",
+          "id": 193,
+          "word": "primary",
+          "wordTranslate": "первичный"
+        },
+        {
+          "audioExample": "files/10_0195_example.mp3",
+          "textExample": "My sister had to remain home since she was sick",
+          "textExampleTranslate": "Моя сестра должна была оставаться дома, так как она была больна",
+          "id": 195,
+          "word": "remain",
+          "wordTranslate": "остаются"
+        },
+        {
+          "audioExample": "files/10_0196_example.mp3",
+          "textExample": "I rested on the couch after work",
+          "textExampleTranslate": "Я отдыхал на диване после работы",
+          "id": 196,
+          "word": "rest",
+          "wordTranslate": "остаток"
+        },
+        {
+          "audioExample": "files/10_0198_example.mp3",
+          "textExample": "We found the perfect site for our picnic",
+          "textExampleTranslate": "Мы нашли идеальное место для нашего пикника",
+          "id": 198,
+          "word": "site",
+          "wordTranslate": "сайт"
+        },
+        {
+          "audioExample": "files/10_0199_example.mp3",
+          "textExample": "Our dog wags its tail when it’s happy",
+          "textExampleTranslate": "Наша собака виляет хвостом, когда она счастлива",
+          "id": 199,
+          "word": "tail",
+          "wordTranslate": "хвост"
+        },
+        {
+          "audioExample": "files/10_0200_example.mp3",
+          "textExample": "I have trouble working with my boss",
+          "textExampleTranslate": "У меня проблемы с работой с моим боссом",
+          "id": 200,
+          "word": "trouble",
+          "wordTranslate": "беда"
+        },
+        {
+          "audioExample": "files/11_0202_example.mp3",
+          "textExample": "The student became aware that the teacher was watching him",
+          "textExampleTranslate": "Ученик осознал, что учитель следит за ним",
+          "id": 202,
+          "word": "aware",
+          "wordTranslate": "знают"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_17",
+        "name": "Shipping in a Calm Sea off the Coast",
+        "imageSrc": "level1/shipcalm.jpg",
+        "cutSrc": "level1/cut/shipcalm.jpg",
+        "author": "ANDERSON, William",
+        "year": "1803"
+      },
+      "words": [
+        {
+          "audioExample": "files/11_0203_example.mp3",
+          "textExample": "My brother needs a battery for his clock",
+          "textExampleTranslate": "Моему брату нужна батарея для его часов",
+          "id": 203,
+          "word": "battery",
+          "wordTranslate": "батарея"
+        },
+        {
+          "audioExample": "files/11_0205_example.mp3",
+          "textExample": "Tokyo is a very big city in Japan",
+          "textExampleTranslate": "Токио - очень большой город в Японии",
+          "id": 205,
+          "word": "city",
+          "wordTranslate": "город"
+        },
+        {
+          "audioExample": "files/11_0206_example.mp3",
+          "textExample": "I clean our kitchen every Saturday",
+          "textExampleTranslate": "Я убираю нашу кухню каждую субботу",
+          "id": 206,
+          "word": "clean",
+          "wordTranslate": "чистый"
+        },
+        {
+          "audioExample": "files/11_0207_example.mp3",
+          "textExample": "France is a country in Europe",
+          "textExampleTranslate": "Франция - это страна в Европе",
+          "id": 207,
+          "word": "country",
+          "wordTranslate": "страна"
+        },
+        {
+          "audioExample": "files/11_0208_example.mp3",
+          "textExample": "This practice will help you develop your math skills",
+          "textExampleTranslate": "Эта практика поможет вам развить свои математические навыки",
+          "id": 208,
+          "word": "develop",
+          "wordTranslate": "развивать"
+        },
+        {
+          "audioExample": "files/11_0209_example.mp3",
+          "textExample": "Some car companies make electric cars",
+          "textExampleTranslate": "Некоторые автомобильные компании производят электромобили",
+          "id": 209,
+          "word": "electric",
+          "wordTranslate": "электрический"
+        },
+        {
+          "audioExample": "files/11_0212_example.mp3",
+          "textExample": "Windows are made of glass",
+          "textExampleTranslate": "Окна сделаны из стекла",
+          "id": 212,
+          "word": "glass",
+          "wordTranslate": "стакан"
+        },
+        {
+          "audioExample": "files/11_0213_example.mp3",
+          "textExample": "History was my favorite subject in school",
+          "textExampleTranslate": "История была моим любимым предметом в школе",
+          "id": 213,
+          "word": "history",
+          "wordTranslate": "история"
+        },
+        {
+          "audioExample": "files/11_0215_example.mp3",
+          "textExample": "They never eat meat because they are vegetarians",
+          "textExampleTranslate": "Они никогда не едят мясо, потому что они вегетарианцы",
+          "id": 215,
+          "word": "never",
+          "wordTranslate": "никогда"
+        },
+        {
+          "audioExample": "files/11_0216_example.mp3",
+          "textExample": "How many people live in China?",
+          "textExampleTranslate": "Сколько людей живет в Китае?",
+          "id": 216,
+          "word": "people",
+          "wordTranslate": "люди"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_18",
+        "name": "Shipping on the Thames off Deptford",
+        "imageSrc": "level1/shipping.jpg",
+        "cutSrc": "level1/cut/shipping.jpg",
+        "author": "ANDERSON, William",
+        "year": "1825"
+      },
+      "words": [
+        {
+          "audioExample": "files/11_0217_example.mp3",
+          "textExample": "Many drinks are sold in plastic bottles",
+          "textExampleTranslate": "Многие напитки продаются в пластиковых бутылках",
+          "id": 217,
+          "word": "plastic",
+          "wordTranslate": "пластик"
+        },
+        {
+          "audioExample": "files/11_0218_example.mp3",
+          "textExample": "My problem is that I lost my dog",
+          "textExampleTranslate": "Моя проблема в том, что я потерял свою собаку",
+          "id": 218,
+          "word": "problem",
+          "wordTranslate": "проблема"
+        },
+        {
+          "audioExample": "files/11_0219_example.mp3",
+          "textExample": "What is the name of the street you live on?",
+          "textExampleTranslate": "Как называется улица, на которой вы живете?",
+          "id": 219,
+          "word": "street",
+          "wordTranslate": "улица"
+        },
+        {
+          "audioExample": "files/11_0220_example.mp3",
+          "textExample": "I think summer is the best season",
+          "textExampleTranslate": "Я считаю лето лучшим сезоном",
+          "id": 220,
+          "word": "think",
+          "wordTranslate": "считать"
+        },
+        {
+          "audioExample": "files/12_0221_example.mp3",
+          "textExample": "The boy wanted to be alone to think",
+          "textExampleTranslate": "Мальчик хотел побыть один, чтобы думать",
+          "id": 221,
+          "word": "alone",
+          "wordTranslate": "один"
+        },
+        {
+          "audioExample": "files/12_0222_example.mp3",
+          "textExample": "She has a nice apartment in the city",
+          "textExampleTranslate": "У нее хорошая квартира в городе",
+          "id": 222,
+          "word": "apartment",
+          "wordTranslate": "квартира"
+        },
+        {
+          "audioExample": "files/12_0224_example.mp3",
+          "textExample": "He went to Paris to become an artist",
+          "textExampleTranslate": "Он отправился в Париж, чтобы стать художником",
+          "id": 224,
+          "word": "artist",
+          "wordTranslate": "художник"
+        },
+        {
+          "audioExample": "files/12_0225_example.mp3",
+          "textExample": "John has a bad attitude. He’s always angry",
+          "textExampleTranslate": "У Джона плохое отношение. Он всегда зол",
+          "id": 225,
+          "word": "attitude",
+          "wordTranslate": "отношение"
+        },
+        {
+          "audioExample": "files/12_0229_example.mp3",
+          "textExample": "She likes to read fashion magazines",
+          "textExampleTranslate": "Она любит читать журналы мод",
+          "id": 229,
+          "word": "magazine",
+          "wordTranslate": "журнал"
+        },
+        {
+          "audioExample": "files/12_0230_example.mp3",
+          "textExample": "Brick is a good material for building houses",
+          "textExampleTranslate": "Кирпич - хороший материал для строительства домов",
+          "id": 230,
+          "word": "material",
+          "wordTranslate": "материал"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_19",
+        "name": "Italianate Coastal Landscape",
+        "imageSrc": "level1/landsca3.jpg",
+        "cutSrc": "level1/cut/landsca3.jpg",
+        "author": "ANESI, Paolo",
+        "year": "XVIII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/12_0231_example.mp3",
+          "textExample": "Breakfast is my favorite meal because I enjoy cereal",
+          "textExampleTranslate": "Завтрак - моя любимая еда, потому что я наслаждаюсь хлопьями",
+          "id": 231,
+          "word": "meal",
+          "wordTranslate": "еда"
+        },
+        {
+          "audioExample": "files/12_0233_example.mp3",
+          "textExample": "I like my neighbor because he’s very friendly",
+          "textExampleTranslate": "Мне нравится мой сосед, потому что он очень дружелюбный",
+          "id": 233,
+          "word": "neighbor",
+          "wordTranslate": "сосед"
+        },
+        {
+          "audioExample": "files/12_0235_example.mp3",
+          "textExample": "I made a small profit from selling my old clothes",
+          "textExampleTranslate": "Я получил небольшую прибыль от продажи моей старой одежды",
+          "id": 235,
+          "word": "profit",
+          "wordTranslate": "прибыль"
+        },
+        {
+          "audioExample": "files/12_0236_example.mp3",
+          "textExample": "The quality of his car is very good",
+          "textExampleTranslate": "Качество его машины очень хорошее",
+          "id": 236,
+          "word": "quality",
+          "wordTranslate": "качественный"
+        },
+        {
+          "audioExample": "files/12_0238_example.mp3",
+          "textExample": "You can take the stairs to the second floor",
+          "textExampleTranslate": "Вы можете подняться по лестнице на второй этаж",
+          "id": 238,
+          "word": "stair",
+          "wordTranslate": "ступенька"
+        },
+        {
+          "audioExample": "files/12_0240_example.mp3",
+          "textExample": "The man was thin because he didn’t eat much",
+          "textExampleTranslate": "Человек был худым, потому что он мало ел",
+          "id": 240,
+          "word": "thin",
+          "wordTranslate": "тонкий"
+        },
+        {
+          "audioExample": "files/13_0241_example.mp3",
+          "textExample": "He works for an accounting firm",
+          "textExampleTranslate": "Он работает в бухгалтерской фирме",
+          "id": 241,
+          "word": "accounting",
+          "wordTranslate": "бухгалтерский учет"
+        },
+        {
+          "audioExample": "files/13_0243_example.mp3",
+          "textExample": "I assume you are both familiar with this plan",
+          "textExampleTranslate": "Я полагаю, вы оба знакомы с этим планом",
+          "id": 243,
+          "word": "assume",
+          "wordTranslate": "предполагать"
+        },
+        {
+          "audioExample": "files/13_0245_example.mp3",
+          "textExample": "She has many clients who enjoy coming to her salon",
+          "textExampleTranslate": "У нее много клиентов, которым нравится приходить в ее салон",
+          "id": 245,
+          "word": "client",
+          "wordTranslate": "клиент"
+        },
+        {
+          "audioExample": "files/13_0246_example.mp3",
+          "textExample": "The downtown area is filled with many tall buildings",
+          "textExampleTranslate": "Центр города заполнен множеством высоких зданий",
+          "id": 246,
+          "word": "downtown",
+          "wordTranslate": "центр города"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_20",
+        "name": "Tiber Bridge in Rome",
+        "imageSrc": "level1/rome.jpg",
+        "cutSrc": "level1/cut/rome.jpg",
+        "author": "ANESI, Paolo",
+        "year": "XVIII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/13_0247_example.mp3",
+          "textExample": "The movie was very dull. I fell asleep watching it",
+          "textExampleTranslate": "Фильм был очень скучным. Я заснул, смотря его",
+          "id": 247,
+          "word": "dull",
+          "wordTranslate": "тупой"
+        },
+        {
+          "audioExample": "files/13_0248_example.mp3",
+          "textExample": "He was embarrassed when he couldn’t remember her name",
+          "textExampleTranslate": "Он был смущен, когда не мог вспомнить ее имя",
+          "id": 248,
+          "word": "embarrass",
+          "wordTranslate": "смущать"
+        },
+        {
+          "audioExample": "files/13_0253_example.mp3",
+          "textExample": "I got a loan from the bank",
+          "textExampleTranslate": "Я получил кредит в банке",
+          "id": 253,
+          "word": "loan",
+          "wordTranslate": "кредит"
+        },
+        {
+          "audioExample": "files/13_0255_example.mp3",
+          "textExample": "He paid a quarter for the candy",
+          "textExampleTranslate": "Он заплатил четверть за конфету",
+          "id": 255,
+          "word": "quarter",
+          "wordTranslate": "квартал"
+        },
+        {
+          "audioExample": "files/13_0256_example.mp3",
+          "textExample": "He got a new job with a better salary",
+          "textExampleTranslate": "Он получил новую работу с лучшей зарплатой",
+          "id": 256,
+          "word": "salary",
+          "wordTranslate": "зарплата"
+        },
+        {
+          "audioExample": "files/13_0257_example.mp3",
+          "textExample": "I got a scholarship to help me pay for university",
+          "textExampleTranslate": "Я получил стипендию, чтобы помочь мне заплатить за университет",
+          "id": 257,
+          "word": "scholarship",
+          "wordTranslate": "стипендия"
+        },
+        {
+          "audioExample": "files/13_0259_example.mp3",
+          "textExample": "They became very rich when they found the buried treasure",
+          "textExampleTranslate": "Они стали очень богатыми, когда нашли клад",
+          "id": 259,
+          "word": "treasure",
+          "wordTranslate": "сокровище"
+        },
+        {
+          "audioExample": "files/13_0260_example.mp3",
+          "textExample": "He urged them to believe his story",
+          "textExampleTranslate": "Он призвал их поверить в его историю",
+          "id": 260,
+          "word": "urge",
+          "wordTranslate": "побуждение"
+        },
+        {
+          "audioExample": "files/14_0261_example.mp3",
+          "textExample": "My coach gets very excited during games",
+          "textExampleTranslate": "Мой тренер очень взволнован во время игр",
+          "id": 261,
+          "word": "coach",
+          "wordTranslate": "тренер"
+        },
+        {
+          "audioExample": "files/14_0262_example.mp3",
+          "textExample": "To control the TV, just push the buttons",
+          "textExampleTranslate": "Чтобы управлять телевизором, просто нажимайте кнопки",
+          "id": 262,
+          "word": "control",
+          "wordTranslate": "контроль"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_21",
+        "name": "View of the Roman Campagna",
+        "imageSrc": "level1/rome1.jpg",
+        "cutSrc": "level1/cut/rome1.jpg",
+        "author": "ANESI, Paolo",
+        "year": "XVIII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/14_0264_example.mp3",
+          "textExample": "The green path is a direct route to my house",
+          "textExampleTranslate": "Зеленая тропа - прямой путь к моему дому",
+          "id": 264,
+          "word": "direct",
+          "wordTranslate": "непосредственный"
+        },
+        {
+          "audioExample": "files/14_0266_example.mp3",
+          "textExample": "Cola is an example of a soft drink",
+          "textExampleTranslate": "Кола - пример безалкогольного напитка",
+          "id": 266,
+          "word": "example",
+          "wordTranslate": "пример"
+        },
+        {
+          "audioExample": "files/14_0269_example.mp3",
+          "textExample": "The fireworks made the night sky look so magical",
+          "textExampleTranslate": "Фейерверк заставил ночное небо выглядеть таким волшебным",
+          "id": 269,
+          "word": "magical",
+          "wordTranslate": "волшебный"
+        },
+        {
+          "audioExample": "files/14_0271_example.mp3",
+          "textExample": "He wrote a great novel about ancient China",
+          "textExampleTranslate": "Он написал великий роман о древнем Китае",
+          "id": 271,
+          "word": "novel",
+          "wordTranslate": "роман"
+        },
+        {
+          "audioExample": "files/14_0272_example.mp3",
+          "textExample": "Before I wrote my essay, I made an outline",
+          "textExampleTranslate": "Прежде чем я написал свое эссе, я сделал набросок",
+          "id": 272,
+          "word": "outline",
+          "wordTranslate": "контур"
+        },
+        {
+          "audioExample": "files/14_0273_example.mp3",
+          "textExample": "William Shakespeare was one of the greatest poets",
+          "textExampleTranslate": "Уильям Шекспир был одним из величайших поэтов",
+          "id": 273,
+          "word": "poet",
+          "wordTranslate": "поэт"
+        },
+        {
+          "audioExample": "files/14_0274_example.mp3",
+          "textExample": "Make sure that you print your name clearly",
+          "textExampleTranslate": "Убедитесь, что вы печатаете свое имя четко",
+          "id": 274,
+          "word": "print",
+          "wordTranslate": "распечатать"
+        },
+        {
+          "audioExample": "files/14_0277_example.mp3",
+          "textExample": "I made a silly mistake of dropping mom’s vase",
+          "textExampleTranslate": "Я сделал глупую ошибку, уронив мамину вазу",
+          "id": 277,
+          "word": "silly",
+          "wordTranslate": "глупый"
+        },
+        {
+          "audioExample": "files/14_0278_example.mp3",
+          "textExample": "I picked up a few things at the grocery store",
+          "textExampleTranslate": "Я взял несколько вещей в продуктовом магазине",
+          "id": 278,
+          "word": "store",
+          "wordTranslate": "хранить"
+        },
+        {
+          "audioExample": "files/14_0279_example.mp3",
+          "textExample": "Her headache made her suffer all day",
+          "textExampleTranslate": "Ее головная боль заставляла ее страдать весь день",
+          "id": 279,
+          "word": "suffer",
+          "wordTranslate": "страдать"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_22",
+        "name": "Harbour Scene",
+        "imageSrc": "level1/scene.jpg",
+        "cutSrc": "level1/cut/scene.jpg",
+        "author": "ANESI, Paolo",
+        "year": "XVIII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/14_0280_example.mp3",
+          "textExample": "He loves technology such as laptop computers",
+          "textExampleTranslate": "Он любит такие технологии, как ноутбуки",
+          "id": 280,
+          "word": "technology",
+          "wordTranslate": "технологии"
+        },
+        {
+          "audioExample": "files/15_0281_example.mp3",
+          "textExample": "He walked across the board to the other side",
+          "textExampleTranslate": "Он прошел через доску на другую сторону",
+          "id": 281,
+          "word": "across",
+          "wordTranslate": "через"
+        },
+        {
+          "audioExample": "files/15_0282_example.mp3",
+          "textExample": "We need strong healthy lungs to help us breathe well",
+          "textExampleTranslate": "Нам нужны крепкие здоровые легкие, чтобы мы могли хорошо дышать",
+          "id": 282,
+          "word": "breathe",
+          "wordTranslate": "дышать"
+        },
+        {
+          "audioExample": "files/15_0283_example.mp3",
+          "textExample": "One characteristic of tigers is their black stripes",
+          "textExampleTranslate": "Одна из характеристик тигров - их черные полосы",
+          "id": 283,
+          "word": "characteristic",
+          "wordTranslate": "характеристика"
+        },
+        {
+          "audioExample": "files/15_0284_example.mp3",
+          "textExample": "Jack consumed a whole plate of spaghetti",
+          "textExampleTranslate": "Джек съел целую тарелку спагетти",
+          "id": 284,
+          "word": "consume",
+          "wordTranslate": "потреблять"
+        },
+        {
+          "audioExample": "files/15_0286_example.mp3",
+          "textExample": "I was extremely worried about him",
+          "textExampleTranslate": "Я очень переживал за него",
+          "id": 286,
+          "word": "extremely",
+          "wordTranslate": "чрезвычайно"
+        },
+        {
+          "audioExample": "files/15_0287_example.mp3",
+          "textExample": "I have a great fear of skateboarding",
+          "textExampleTranslate": "Я очень боюсь кататься на скейтборде",
+          "id": 287,
+          "word": "fear",
+          "wordTranslate": "страх"
+        },
+        {
+          "audioExample": "files/15_0288_example.mp3",
+          "textExample": "I was fortunate to get a seat",
+          "textExampleTranslate": "Мне повезло получить место",
+          "id": 288,
+          "word": "fortunate",
+          "wordTranslate": "повезло"
+        },
+        {
+          "audioExample": "files/15_0289_example.mp3",
+          "textExample": "I happened to meet some new friends at school today",
+          "textExampleTranslate": "Я случайно встретил в школе новых друзей",
+          "id": 289,
+          "word": "happen",
+          "wordTranslate": "случиться"
+        },
+        {
+          "audioExample": "files/15_0290_example.mp3",
+          "textExample": "The length of the floor is three meters",
+          "textExampleTranslate": "Длина пола три метра",
+          "id": 290,
+          "word": "length",
+          "wordTranslate": "длина"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_23",
+        "name": "View of Tivoli and the Roman Campagna",
+        "imageSrc": "level1/tivoli.jpg",
+        "cutSrc": "level1/cut/tivoli.jpg",
+        "author": "ANESI, Paolo",
+        "year": "XVIII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/15_0292_example.mp3",
+          "textExample": "Brian observed the sun rising over the mountains",
+          "textExampleTranslate": "Брайан наблюдал, как солнце поднимается над горами",
+          "id": 292,
+          "word": "observe",
+          "wordTranslate": "наблюдать"
+        },
+        {
+          "audioExample": "files/15_0293_example.mp3",
+          "textExample": "I had an opportunity to take pictures in the jungle",
+          "textExampleTranslate": "У меня была возможность фотографироваться в джунглях",
+          "id": 293,
+          "word": "opportunity",
+          "wordTranslate": "возможность"
+        },
+        {
+          "audioExample": "files/15_0297_example.mp3",
+          "textExample": "When the teacher asked the question, we all responded",
+          "textExampleTranslate": "Когда учитель задал вопрос, мы все ответили",
+          "id": 297,
+          "word": "respond",
+          "wordTranslate": "отвечать"
+        },
+        {
+          "audioExample": "files/15_0298_example.mp3",
+          "textExample": "I took a risk and climbed the snowy mountain",
+          "textExampleTranslate": "Я рискнул и поднялся на снежную гору",
+          "id": 298,
+          "word": "risk",
+          "wordTranslate": "риск"
+        },
+        {
+          "audioExample": "files/15_0300_example.mp3",
+          "textExample": "We can’t go out yet; we’re still eating",
+          "textExampleTranslate": "Мы еще не можем выйти; мы все еще едим",
+          "id": 300,
+          "word": "yet",
+          "wordTranslate": "еще"
+        },
+        {
+          "audioExample": "files/16_0302_example.mp3",
+          "textExample": "The man smiles as he reads his favorite book",
+          "textExampleTranslate": "Человек улыбается, читая свою любимую книгу",
+          "id": 302,
+          "word": "book",
+          "wordTranslate": "книга"
+        },
+        {
+          "audioExample": "files/16_0303_example.mp3",
+          "textExample": "I bought warm clothes for the cold winter",
+          "textExampleTranslate": "Я купил теплую одежду для холодной зимы",
+          "id": 303,
+          "word": "clothes",
+          "wordTranslate": "одежда"
+        },
+        {
+          "audioExample": "files/16_0304_example.mp3",
+          "textExample": "The community got together to plant trees",
+          "textExampleTranslate": "Община собралась сажать деревья",
+          "id": 304,
+          "word": "community",
+          "wordTranslate": "сообщество"
+        },
+        {
+          "audioExample": "files/16_0305_example.mp3",
+          "textExample": "The last day of the year is December 31st",
+          "textExampleTranslate": "Последний день года - 31 декабря",
+          "id": 305,
+          "word": "December",
+          "wordTranslate": "декабрь"
+        },
+        {
+          "audioExample": "files/16_0306_example.mp3",
+          "textExample": "I had a hamburger for dinner",
+          "textExampleTranslate": "У меня был гамбургер на ужин",
+          "id": 306,
+          "word": "dinner",
+          "wordTranslate": "обед"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_24",
+        "name": "The Western Railway Leaving Paris",
+        "imageSrc": "level1/railway.jpg",
+        "cutSrc": "level1/cut/railway.jpg",
+        "author": "ANGRAND, Charles",
+        "year": "1886"
+      },
+      "words": [
+        {
+          "audioExample": "files/16_0308_example.mp3",
+          "textExample": "The men exchange business cards",
+          "textExampleTranslate": "Мужчины обмениваются визитками",
+          "id": 308,
+          "word": "exchange",
+          "wordTranslate": "обмен"
+        },
+        {
+          "audioExample": "files/16_0309_example.mp3",
+          "textExample": "There are four people in my family",
+          "textExampleTranslate": "В моей семье четыре человека",
+          "id": 309,
+          "word": "family",
+          "wordTranslate": "семья"
+        },
+        {
+          "audioExample": "files/16_0310_example.mp3",
+          "textExample": "Chris studies from 10 o’clock to noon every morning",
+          "textExampleTranslate": "Крис учится с 10 до 12 часов каждое утро",
+          "id": 310,
+          "word": "from",
+          "wordTranslate": "от"
+        },
+        {
+          "audioExample": "files/16_0311_example.mp3",
+          "textExample": "I don’t like green apples",
+          "textExampleTranslate": "Я не люблю зеленые яблоки",
+          "id": 311,
+          "word": "green",
+          "wordTranslate": "зеленый"
+        },
+        {
+          "audioExample": "files/16_0312_example.mp3",
+          "textExample": "The family likes to stay at home on the weekends",
+          "textExampleTranslate": "Семья любит сидеть дома по выходным",
+          "id": 312,
+          "word": "home",
+          "wordTranslate": "дом"
+        },
+        {
+          "audioExample": "files/16_0313_example.mp3",
+          "textExample": "My birthday is in January",
+          "textExampleTranslate": "Мой день рождения в январе",
+          "id": 313,
+          "word": "January",
+          "wordTranslate": "январь"
+        },
+        {
+          "audioExample": "files/16_0314_example.mp3",
+          "textExample": "Jack is wearing a red shirt",
+          "textExampleTranslate": "Джек одет в красную рубашку",
+          "id": 314,
+          "word": "red",
+          "wordTranslate": "красный"
+        },
+        {
+          "audioExample": "files/16_0315_example.mp3",
+          "textExample": "I have seven colored pencils on my desk",
+          "textExampleTranslate": "У меня на столе семь цветных карандашей",
+          "id": 315,
+          "word": "seven",
+          "wordTranslate": "семь"
+        },
+        {
+          "audioExample": "files/16_0317_example.mp3",
+          "textExample": "Let’s work together to finish the project",
+          "textExampleTranslate": "Давайте работать вместе, чтобы закончить проект",
+          "id": 317,
+          "word": "together",
+          "wordTranslate": "все вместе"
+        },
+        {
+          "audioExample": "files/16_0318_example.mp3",
+          "textExample": "My dream is to go to a good university",
+          "textExampleTranslate": "Моя мечта - поступить в хороший университет",
+          "id": 318,
+          "word": "university",
+          "wordTranslate": "университет"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_25",
+        "name": "Landscape with a Musician",
+        "imageSrc": "level1/landscap.jpg",
+        "cutSrc": "level1/cut/landscap.jpg",
+        "author": "APSHOVEN, Thomas van",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/16_0319_example.mp3",
+          "textExample": "The man has to wear a suit to work",
+          "textExampleTranslate": "Человек должен носить костюм, чтобы работать",
+          "id": 319,
+          "word": "wear",
+          "wordTranslate": "износ"
+        },
+        {
+          "audioExample": "files/16_0320_example.mp3",
+          "textExample": "You become one year older every birthday",
+          "textExampleTranslate": "Вы становитесь на год старше с каждым днем рождения",
+          "id": 320,
+          "word": "year",
+          "wordTranslate": "год"
+        },
+        {
+          "audioExample": "files/17_0321_example.mp3",
+          "textExample": "I can appreciate the lovely scenery",
+          "textExampleTranslate": "Я могу оценить прекрасные пейзажи",
+          "id": 321,
+          "word": "appreciate",
+          "wordTranslate": "оценить"
+        },
+        {
+          "audioExample": "files/17_0322_example.mp3",
+          "textExample": "There were many seats available in the room",
+          "textExampleTranslate": "В комнате было много свободных мест",
+          "id": 322,
+          "word": "available",
+          "wordTranslate": "доступный"
+        },
+        {
+          "audioExample": "files/17_0323_example.mp3",
+          "textExample": "I managed to beat everyone in the race",
+          "textExampleTranslate": "Мне удалось победить всех в гонке",
+          "id": 323,
+          "word": "beat",
+          "wordTranslate": "бить"
+        },
+        {
+          "audioExample": "files/17_0324_example.mp3",
+          "textExample": "The bright light from the explosion hurt my eyes",
+          "textExampleTranslate": "Яркий свет от взрыва повредил мне глаза",
+          "id": 324,
+          "word": "bright",
+          "wordTranslate": "яркий"
+        },
+        {
+          "audioExample": "files/17_0325_example.mp3",
+          "textExample": "We all celebrated when we heard the great news",
+          "textExampleTranslate": "Мы все праздновали, когда услышали великие новости",
+          "id": 325,
+          "word": "celebrate",
+          "wordTranslate": "праздновать"
+        },
+        {
+          "audioExample": "files/17_0326_example.mp3",
+          "textExample": "He tried to decide which one to eat first",
+          "textExampleTranslate": "Он пытался решить, какой из них съесть первым",
+          "id": 326,
+          "word": "decide",
+          "wordTranslate": "принять решение"
+        },
+        {
+          "audioExample": "files/17_0327_example.mp3",
+          "textExample": "The top of the building is disappearing in the clouds",
+          "textExampleTranslate": "Верхняя часть здания исчезает в облаках",
+          "id": 327,
+          "word": "disappear",
+          "wordTranslate": "исчезают"
+        },
+        {
+          "audioExample": "files/17_0329_example.mp3",
+          "textExample": "He sold me his car for a fair price",
+          "textExampleTranslate": "Он продал мне свою машину по справедливой цене",
+          "id": 329,
+          "word": "fair",
+          "wordTranslate": "справедливая"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_26",
+        "name": "Edge of a Wood",
+        "imageSrc": "level1/edgewood.jpg",
+        "cutSrc": "level1/cut/edgewood.jpg",
+        "author": "ARTHOIS, Jacques d'",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/17_0330_example.mp3",
+          "textExample": "The water flowed over the rocks and into the lake",
+          "textExampleTranslate": "Вода текла по скалам и в озеро",
+          "id": 330,
+          "word": "flow",
+          "wordTranslate": "течь"
+        },
+        {
+          "audioExample": "files/17_0332_example.mp3",
+          "textExample": "The sun was rising above the green hills",
+          "textExampleTranslate": "Солнце поднималось над зелеными холмами",
+          "id": 332,
+          "word": "hill",
+          "wordTranslate": "холм"
+        },
+        {
+          "audioExample": "files/17_0333_example.mp3",
+          "textExample": "Please check the level of the temperature",
+          "textExampleTranslate": "Пожалуйста, проверьте уровень температуры",
+          "id": 333,
+          "word": "level",
+          "wordTranslate": "уровень"
+        },
+        {
+          "audioExample": "files/17_0334_example.mp3",
+          "textExample": "A lone man walked along the street",
+          "textExampleTranslate": "Одинокий человек шел по улице",
+          "id": 334,
+          "word": "lone",
+          "wordTranslate": "одинокий"
+        },
+        {
+          "audioExample": "files/17_0335_example.mp3",
+          "textExample": "When the ice melted, it formed a puddle",
+          "textExampleTranslate": "Когда лед растаял, образовалась лужа",
+          "id": 335,
+          "word": "puddle",
+          "wordTranslate": "лужа"
+        },
+        {
+          "audioExample": "files/17_0336_example.mp3",
+          "textExample": "He asked if I was sad. My response was “No.”",
+          "textExampleTranslate": "Он спросил, грустно ли мне. Мой ответ был 'Нет'",
+          "id": 336,
+          "word": "response",
+          "wordTranslate": "ответ"
+        },
+        {
+          "audioExample": "files/17_0337_example.mp3",
+          "textExample": "Fall is a warm season, while winter is very cold",
+          "textExampleTranslate": "Осень - теплое время года, а зима очень холодная",
+          "id": 337,
+          "word": "season",
+          "wordTranslate": "время года"
+        },
+        {
+          "audioExample": "files/17_0338_example.mp3",
+          "textExample": "There are many problems. We need solutions!",
+          "textExampleTranslate": "Есть много проблем. Нам нужны решения!",
+          "id": 338,
+          "word": "solution",
+          "wordTranslate": "решение"
+        },
+        {
+          "audioExample": "files/17_0339_example.mp3",
+          "textExample": "Turn off the water so you don’t waste it",
+          "textExampleTranslate": "Выключи воду, чтобы не тратить ее впустую",
+          "id": 339,
+          "word": "waste",
+          "wordTranslate": "отходы"
+        },
+        {
+          "audioExample": "files/17_0340_example.mp3",
+          "textExample": "I could not decide whether to go left or right",
+          "textExampleTranslate": "Я не мог решить, идти ли налево или направо",
+          "id": 340,
+          "word": "whether",
+          "wordTranslate": "будь то"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_27",
+        "name": "An Extensive Wooded Landscape with Travellers on a Path",
+        "imageSrc": "level1/extensiv_1.jpg",
+        "cutSrc": "level1/cut/extensiv_1.jpg",
+        "author": "ARTHOIS, Jacques d'",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/18_0341_example.mp3",
+          "textExample": "They always brush their teeth in the morning",
+          "textExampleTranslate": "Они всегда чистят зубы по утрам",
+          "id": 341,
+          "word": "always",
+          "wordTranslate": "всегда"
+        },
+        {
+          "audioExample": "files/18_0342_example.mp3",
+          "textExample": "Please ask questions if you do not understand",
+          "textExampleTranslate": "Пожалуйста, задавайте вопросы, если вы не понимаете",
+          "id": 342,
+          "word": "ask",
+          "wordTranslate": "спросить"
+        },
+        {
+          "audioExample": "files/18_0343_example.mp3",
+          "textExample": "Did you eat a banana for breakfast?",
+          "textExampleTranslate": "Ты ел банан на завтрак?",
+          "id": 343,
+          "word": "banana",
+          "wordTranslate": "банан"
+        },
+        {
+          "audioExample": "files/18_0344_example.mp3",
+          "textExample": "You need two pieces of bread to make a sandwich",
+          "textExampleTranslate": "Вам нужно два куска хлеба, чтобы сделать бутерброд",
+          "id": 344,
+          "word": "bread",
+          "wordTranslate": "хлеб"
+        },
+        {
+          "audioExample": "files/18_0345_example.mp3",
+          "textExample": "What a beautiful birthday cake!",
+          "textExampleTranslate": "Какой красивый торт ко дню рождения!",
+          "id": 345,
+          "word": "cake",
+          "wordTranslate": "торт"
+        },
+        {
+          "audioExample": "files/18_0346_example.mp3",
+          "textExample": "I put a carrot in my salad",
+          "textExampleTranslate": "Я положил морковку в свой салат",
+          "id": 346,
+          "word": "carrot",
+          "wordTranslate": "морковь"
+        },
+        {
+          "audioExample": "files/18_0347_example.mp3",
+          "textExample": "Chicken is his favorite kind of meat",
+          "textExampleTranslate": "Курица - его любимый вид мяса",
+          "id": 347,
+          "word": "chicken",
+          "wordTranslate": "курица"
+        },
+        {
+          "audioExample": "files/18_0348_example.mp3",
+          "textExample": "I made a chocolate cake for my mom’s party",
+          "textExampleTranslate": "Я сделал шоколадный торт для вечеринки моей мамы",
+          "id": 348,
+          "word": "chocolate",
+          "wordTranslate": "шоколад"
+        },
+        {
+          "audioExample": "files/18_0349_example.mp3",
+          "textExample": "I have to find something to contain these apples",
+          "textExampleTranslate": "Я должен найти что-то, чтобы содержать эти яблоки",
+          "id": 349,
+          "word": "contain",
+          "wordTranslate": "содержать"
+        },
+        {
+          "audioExample": "files/18_0350_example.mp3",
+          "textExample": "I loved the delicious fried chicken I ate for dinner!",
+          "textExampleTranslate": "Мне очень понравилась вкусная жареная курица, которую я ел на ужин!",
+          "id": 350,
+          "word": "delicious",
+          "wordTranslate": "очень вкусно"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_28",
+        "name": "Wooded Landscape",
+        "imageSrc": "level1/landscap_1.jpg",
+        "cutSrc": "level1/cut/landscap_1.jpg",
+        "author": "ARTHOIS, Jacques d'",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/18_0351_example.mp3",
+          "textExample": "His diet mostly consists of fruits and vegetables",
+          "textExampleTranslate": "Его диета состоит в основном из фруктов и овощей",
+          "id": 351,
+          "word": "diet",
+          "wordTranslate": "рацион питания"
+        },
+        {
+          "audioExample": "files/18_0352_example.mp3",
+          "textExample": "You should eat breakfast every day",
+          "textExampleTranslate": "Ты должен завтракать каждый день",
+          "id": 352,
+          "word": "eat",
+          "wordTranslate": "есть"
+        },
+        {
+          "audioExample": "files/18_0353_example.mp3",
+          "textExample": "Pasta is a famous food in Italy",
+          "textExampleTranslate": "Макароны - известная еда в Италии",
+          "id": 353,
+          "word": "food",
+          "wordTranslate": "пища"
+        },
+        {
+          "audioExample": "files/18_0354_example.mp3",
+          "textExample": "Apples, pears, and oranges are types of fruit",
+          "textExampleTranslate": "Яблоки, груши и апельсины - это виды фруктов",
+          "id": 354,
+          "word": "fruit",
+          "wordTranslate": "фрукты"
+        },
+        {
+          "audioExample": "files/18_0355_example.mp3",
+          "textExample": "It was a great, exciting game!",
+          "textExampleTranslate": "Это была отличная, захватывающая игра!",
+          "id": 355,
+          "word": "great",
+          "wordTranslate": "великий"
+        },
+        {
+          "audioExample": "files/18_0356_example.mp3",
+          "textExample": "People who want good health should not smoke",
+          "textExampleTranslate": "Люди, которые хотят хорошего здоровья, не должны курить",
+          "id": 356,
+          "word": "health",
+          "wordTranslate": "здоровье"
+        },
+        {
+          "audioExample": "files/18_0357_example.mp3",
+          "textExample": "Do you use a recipe when you make that sauce?",
+          "textExampleTranslate": "Ты используешь рецепт, когда готовишь этот соус?",
+          "id": 357,
+          "word": "recipe",
+          "wordTranslate": "рецепт блюда"
+        },
+        {
+          "audioExample": "files/18_0358_example.mp3",
+          "textExample": "Let’s eat at the Indian restaurant",
+          "textExampleTranslate": "Давайте есть в индийском ресторане",
+          "id": 358,
+          "word": "restaurant",
+          "wordTranslate": "ресторан"
+        },
+        {
+          "audioExample": "files/18_0359_example.mp3",
+          "textExample": "The cupcake was special because it had blue frosting",
+          "textExampleTranslate": "Кекс был особенным, потому что у него была голубая глазурь",
+          "id": 359,
+          "word": "special",
+          "wordTranslate": "специальный"
+        },
+        {
+          "audioExample": "files/18_0360_example.mp3",
+          "textExample": "Drink eight cups of water every day",
+          "textExampleTranslate": "Пейте восемь чашек воды каждый день",
+          "id": 360,
+          "word": "water",
+          "wordTranslate": "вода"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_29",
+        "name": "Wooded Landscape",
+        "imageSrc": "level1/woodedla.jpg",
+        "cutSrc": "level1/cut/woodedla.jpg",
+        "author": "ARTHOIS, Jacques d'",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/19_0362_example.mp3",
+          "textExample": "I brought home a nice bone for my dog",
+          "textExampleTranslate": "Я принес домой хорошую собаку для моей собаки",
+          "id": 362,
+          "word": "bone",
+          "wordTranslate": "кость"
+        },
+        {
+          "audioExample": "files/19_0363_example.mp3",
+          "textExample": "No one bothered to wash the dishes today",
+          "textExampleTranslate": "Никто не удосужился мыть посуду сегодня",
+          "id": 363,
+          "word": "bother",
+          "wordTranslate": "заморачиваться"
+        },
+        {
+          "audioExample": "files/19_0364_example.mp3",
+          "textExample": "The captain sailed his ship to Australia",
+          "textExampleTranslate": "Капитан отплыл на своем корабле в Австралию",
+          "id": 364,
+          "word": "captain",
+          "wordTranslate": "капитан"
+        },
+        {
+          "audioExample": "files/19_0366_example.mp3",
+          "textExample": "I have doubt that the story is true",
+          "textExampleTranslate": "Я сомневаюсь, что история правдива",
+          "id": 366,
+          "word": "doubt",
+          "wordTranslate": "сомнение"
+        },
+        {
+          "audioExample": "files/19_0367_example.mp3",
+          "textExample": "He wants to explore the world and see new things",
+          "textExampleTranslate": "Он хочет исследовать мир и видеть новые вещи",
+          "id": 367,
+          "word": "explore",
+          "wordTranslate": "исследовать"
+        },
+        {
+          "audioExample": "files/19_0368_example.mp3",
+          "textExample": "I am glad you came to my party",
+          "textExampleTranslate": "Я рад, что ты пришел на мою вечеринку",
+          "id": 368,
+          "word": "glad",
+          "wordTranslate": "рады"
+        },
+        {
+          "audioExample": "files/19_0371_example.mp3",
+          "textExample": "The United Nations is a powerful international organization",
+          "textExampleTranslate": "Организация Объединенных Наций является мощной международной организацией",
+          "id": 371,
+          "word": "international",
+          "wordTranslate": "международный"
+        },
+        {
+          "audioExample": "files/19_0373_example.mp3",
+          "textExample": "The doctors mentioned the problems that the patient was having",
+          "textExampleTranslate": "Врачи упомянули о проблемах, с которыми сталкивался пациент",
+          "id": 373,
+          "word": "mention",
+          "wordTranslate": "отметить"
+        },
+        {
+          "audioExample": "files/19_0374_example.mp3",
+          "textExample": "My mother is seventy years old now",
+          "textExampleTranslate": "Моей маме сейчас семьдесят лет",
+          "id": 374,
+          "word": "old",
+          "wordTranslate": "старый"
+        },
+        {
+          "audioExample": "files/19_0376_example.mp3",
+          "textExample": "People should come together and fix the world’s social problems",
+          "textExampleTranslate": "Люди должны собраться вместе и решить социальные проблемы мира",
+          "id": 376,
+          "word": "social",
+          "wordTranslate": "социальное"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_30",
+        "name": "The Delft City Wall with the Houttuinen",
+        "imageSrc": "level1/citywall.jpg",
+        "cutSrc": "level1/cut/citywall.jpg",
+        "author": "ASCH, Pieter Jansz.van",
+        "year": "1650"
+      },
+      "words": [
+        {
+          "audioExample": "files/19_0377_example.mp3",
+          "textExample": "She gave a speech to the class",
+          "textExampleTranslate": "Она выступила с речью перед классом",
+          "id": 377,
+          "word": "speech",
+          "wordTranslate": "речь"
+        },
+        {
+          "audioExample": "files/19_0379_example.mp3",
+          "textExample": "Santa walked toward my house with a bag of gifts",
+          "textExampleTranslate": "Санта шел к моему дому с мешком подарков",
+          "id": 379,
+          "word": "toward",
+          "wordTranslate": "в сторону"
+        },
+        {
+          "audioExample": "files/19_0380_example.mp3",
+          "textExample": "I put the pieces of wood in a pile",
+          "textExampleTranslate": "Я положил кусочки дерева в кучу",
+          "id": 380,
+          "word": "wood",
+          "wordTranslate": "дерево"
+        },
+        {
+          "audioExample": "files/20_0381_example.mp3",
+          "textExample": "I was happy that I could achieve my goal",
+          "textExampleTranslate": "Я был счастлив, что смог достичь своей цели",
+          "id": 381,
+          "word": "achieve",
+          "wordTranslate": "достижения"
+        },
+        {
+          "audioExample": "files/20_0382_example.mp3",
+          "textExample": "My mother often advises people about their money",
+          "textExampleTranslate": "Моя мама часто советует людям об их деньгах",
+          "id": 382,
+          "word": "advise",
+          "wordTranslate": "советовать"
+        },
+        {
+          "audioExample": "files/20_0384_example.mp3",
+          "textExample": "I learned some basic English skills in school today",
+          "textExampleTranslate": "Я выучил некоторые базовые навыки английского в школе сегодня",
+          "id": 384,
+          "word": "basic",
+          "wordTranslate": "базовый"
+        },
+        {
+          "audioExample": "files/20_0387_example.mp3",
+          "textExample": "The glass was destroyed",
+          "textExampleTranslate": "Стекло было разрушено",
+          "id": 387,
+          "word": "destroy",
+          "wordTranslate": "уничтожить"
+        },
+        {
+          "audioExample": "files/20_0388_example.mp3",
+          "textExample": "The clown entertained the kids at the party",
+          "textExampleTranslate": "Клоун развлекал детей на вечеринке",
+          "id": 388,
+          "word": "entertain",
+          "wordTranslate": "развлекать"
+        },
+        {
+          "audioExample": "files/20_0389_example.mp3",
+          "textExample": "The squirrel had extra nuts for the winter",
+          "textExampleTranslate": "У белки были дополнительные орехи на зиму",
+          "id": 389,
+          "word": "extra",
+          "wordTranslate": "экстра"
+        },
+        {
+          "audioExample": "files/20_0390_example.mp3",
+          "textExample": "Her goal was to become a doctor",
+          "textExampleTranslate": "Ее целью было стать врачом",
+          "id": 390,
+          "word": "goal",
+          "wordTranslate": "цель"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_31",
+        "name": "River Landscape",
+        "imageSrc": "level1/river_la.jpg",
+        "cutSrc": "level1/cut/river_la.jpg",
+        "author": "ASCH, Pieter Jansz. van",
+        "year": "1640"
+      },
+      "words": [
+        {
+          "audioExample": "files/20_0391_example.mp3",
+          "textExample": "Whenever Pinocchio lied to his father, his nose grew",
+          "textExampleTranslate": "Всякий раз, когда Пиноккио лгал своему отцу, его нос рос",
+          "id": 391,
+          "word": "lie",
+          "wordTranslate": "ложь"
+        },
+        {
+          "audioExample": "files/20_0392_example.mp3",
+          "textExample": "This piece of meat I’m eating tastes very good",
+          "textExampleTranslate": "Этот кусок мяса, который я ем, имеет очень хороший вкус",
+          "id": 392,
+          "word": "meat",
+          "wordTranslate": "мясо"
+        },
+        {
+          "audioExample": "files/20_0395_example.mp3",
+          "textExample": "Her face was reflected in the smooth glass",
+          "textExampleTranslate": "Ее лицо отражалось в гладком стекле",
+          "id": 395,
+          "word": "reflect",
+          "wordTranslate": "отражать"
+        },
+        {
+          "audioExample": "files/20_0396_example.mp3",
+          "textExample": "The boy regarded the girl as a good friend",
+          "textExampleTranslate": "Мальчик считал девушку хорошим другом",
+          "id": 396,
+          "word": "regard",
+          "wordTranslate": "учитывая"
+        },
+        {
+          "audioExample": "files/20_0397_example.mp3",
+          "textExample": "He served us our drinks quickly",
+          "textExampleTranslate": "Он подал нам наши напитки быстро",
+          "id": 397,
+          "word": "serve",
+          "wordTranslate": "обслуживать"
+        },
+        {
+          "audioExample": "files/20_0398_example.mp3",
+          "textExample": "Carrots are my favorite vegetable",
+          "textExampleTranslate": "Морковь - мой любимый овощ",
+          "id": 398,
+          "word": "vegetable",
+          "wordTranslate": "растительное"
+        },
+        {
+          "audioExample": "files/20_0399_example.mp3",
+          "textExample": "Many young men died in the war",
+          "textExampleTranslate": "Многие молодые люди погибли на войне",
+          "id": 399,
+          "word": "war",
+          "wordTranslate": "война"
+        },
+        {
+          "audioExample": "files/20_0400_example.mp3",
+          "textExample": "Our house is worth a lot of money",
+          "textExampleTranslate": "Наш дом стоит много денег",
+          "id": 400,
+          "word": "worth",
+          "wordTranslate": "ценность"
+        },
+        {
+          "audioExample": "files/21_0401_example.mp3",
+          "textExample": "She appeared to be sad. She was crying",
+          "textExampleTranslate": "Она казалась грустной. Она плакала",
+          "id": 401,
+          "word": "appear",
+          "wordTranslate": "появляются"
+        },
+        {
+          "audioExample": "files/21_0402_example.mp3",
+          "textExample": "The base of the table has three legs",
+          "textExampleTranslate": "У основания стола три ножки",
+          "id": 402,
+          "word": "base",
+          "wordTranslate": "база"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_32",
+        "name": "View of Killarney",
+        "imageSrc": "level1/kilarney.jpg",
+        "cutSrc": "level1/cut/kilarney.jpg",
+        "author": "ASHFORD, William",
+        "year": "1778"
+      },
+      "words": [
+        {
+          "audioExample": "files/21_0403_example.mp3",
+          "textExample": "You must use your brain to solve the problem",
+          "textExampleTranslate": "Вы должны использовать свой мозг, чтобы решить проблему",
+          "id": 403,
+          "word": "brain",
+          "wordTranslate": "головной мозг"
+        },
+        {
+          "audioExample": "files/21_0405_example.mp3",
+          "textExample": "The clerk added up her bill for the groceries",
+          "textExampleTranslate": "Клерк сложил свой счет за продукты",
+          "id": 405,
+          "word": "clerk",
+          "wordTranslate": "клерк"
+        },
+        {
+          "audioExample": "files/21_0406_example.mp3",
+          "textExample": "He always puts a lot of effort into his studies",
+          "textExampleTranslate": "Он всегда прикладывает много усилий к учебе",
+          "id": 406,
+          "word": "effort",
+          "wordTranslate": "усилие"
+        },
+        {
+          "audioExample": "files/21_0407_example.mp3",
+          "textExample": "Two guards greeted me as I entered the front door",
+          "textExampleTranslate": "Два охранника встретили меня, когда я вошел в переднюю дверь",
+          "id": 407,
+          "word": "enter",
+          "wordTranslate": "войти"
+        },
+        {
+          "audioExample": "files/21_0408_example.mp3",
+          "textExample": "I got an excellent score on my school test",
+          "textExampleTranslate": "Я получил отличную оценку на школьном тесте",
+          "id": 408,
+          "word": "excellent",
+          "wordTranslate": "отлично"
+        },
+        {
+          "audioExample": "files/21_0410_example.mp3",
+          "textExample": "I hurried home on my bike",
+          "textExampleTranslate": "Я поспешил домой на своем велосипеде",
+          "id": 410,
+          "word": "hurry",
+          "wordTranslate": "торопиться"
+        },
+        {
+          "audioExample": "files/21_0411_example.mp3",
+          "textExample": "I called and informed her about my idea",
+          "textExampleTranslate": "Я позвонил и сообщил ей о своей идее",
+          "id": 411,
+          "word": "inform",
+          "wordTranslate": "сообщить"
+        },
+        {
+          "audioExample": "files/21_0414_example.mp3",
+          "textExample": "I could not locate my keys in the house",
+          "textExampleTranslate": "Я не мог найти свои ключи в доме",
+          "id": 414,
+          "word": "locate",
+          "wordTranslate": "найти"
+        },
+        {
+          "audioExample": "files/21_0415_example.mp3",
+          "textExample": "A nurse helped me get better",
+          "textExampleTranslate": "Медсестра помогла мне поправиться",
+          "id": 415,
+          "word": "nurse",
+          "wordTranslate": "медсестра"
+        },
+        {
+          "audioExample": "files/21_0416_example.mp3",
+          "textExample": "The operation on my arm was a success",
+          "textExampleTranslate": "Операция на моей руке прошла успешно",
+          "id": 416,
+          "word": "operation",
+          "wordTranslate": "операция"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_33",
+        "name": "Landscape with Waterfall and Farm",
+        "imageSrc": "level1/waterfal.jpg",
+        "cutSrc": "level1/cut/waterfal.jpg",
+        "author": "ASSCHE, Henri van",
+        "year": "1806"
+      },
+      "words": [
+        {
+          "audioExample": "files/21_0417_example.mp3",
+          "textExample": "His head was full of pain",
+          "textExampleTranslate": "Его голова была полна боли",
+          "id": 417,
+          "word": "pain",
+          "wordTranslate": "боль"
+        },
+        {
+          "audioExample": "files/21_0418_example.mp3",
+          "textExample": "The dog refused to play with the cat",
+          "textExampleTranslate": "Собака отказалась играть с кошкой",
+          "id": 418,
+          "word": "refuse",
+          "wordTranslate": "отказываться"
+        },
+        {
+          "audioExample": "files/21_0419_example.mp3",
+          "textExample": "Though he was overweight, he liked to be active",
+          "textExampleTranslate": "Хотя он весил больше нормы, ему нравилось быть активным",
+          "id": 419,
+          "word": "though",
+          "wordTranslate": "хоть"
+        },
+        {
+          "audioExample": "files/21_0420_example.mp3",
+          "textExample": "She owned shoes of various styles",
+          "textExampleTranslate": "Она владела обувью разных стилей",
+          "id": 420,
+          "word": "various",
+          "wordTranslate": "разные"
+        },
+        {
+          "audioExample": "files/22_0422_example.mp3",
+          "textExample": "The news in the paper amazed Jack",
+          "textExampleTranslate": "Новости в газете поразили Джека",
+          "id": 422,
+          "word": "amaze",
+          "wordTranslate": "поражают"
+        },
+        {
+          "audioExample": "files/22_0423_example.mp3",
+          "textExample": "The charge for the shirts was $15",
+          "textExampleTranslate": "Плата за футболки составила 15 долларов",
+          "id": 423,
+          "word": "charge",
+          "wordTranslate": "обвинять"
+        },
+        {
+          "audioExample": "files/22_0425_example.mp3",
+          "textExample": "I contacted Sue about my party",
+          "textExampleTranslate": "Я связался с Сью по поводу моей вечеринки",
+          "id": 425,
+          "word": "contact",
+          "wordTranslate": "контакт"
+        },
+        {
+          "audioExample": "files/22_0426_example.mp3",
+          "textExample": "The customer put a few items in a bag",
+          "textExampleTranslate": "Клиент положил несколько вещей в сумку",
+          "id": 426,
+          "word": "customer",
+          "wordTranslate": "клиент"
+        },
+        {
+          "audioExample": "files/22_0427_example.mp3",
+          "textExample": "The man delivered Chinese food to my house",
+          "textExampleTranslate": "Мужчина доставил китайскую еду в мой дом",
+          "id": 427,
+          "word": "deliver",
+          "wordTranslate": "доставить"
+        },
+        {
+          "audioExample": "files/22_0430_example.mp3",
+          "textExample": "Does this meal include a soft drink?",
+          "textExampleTranslate": "Включает ли это блюдо безалкогольный напиток?",
+          "id": 430,
+          "word": "include",
+          "wordTranslate": "включают"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_34",
+        "name": "Winter Landscape",
+        "imageSrc": "level1/winterla_1.jpg",
+        "cutSrc": "level1/cut/winterla_1.jpg",
+        "author": "ASSCHE, Henri van",
+        "year": "1814"
+      },
+      "words": [
+        {
+          "audioExample": "files/22_0431_example.mp3",
+          "textExample": "I had to manage the meeting myself",
+          "textExampleTranslate": "Я должен был сам управлять встречей",
+          "id": 431,
+          "word": "manage",
+          "wordTranslate": "управлять"
+        },
+        {
+          "audioExample": "files/22_0433_example.mp3",
+          "textExample": "When did the thunderstorm occur?",
+          "textExampleTranslate": "Когда произошла гроза?",
+          "id": 433,
+          "word": "occur",
+          "wordTranslate": "происходят"
+        },
+        {
+          "audioExample": "files/22_0434_example.mp3",
+          "textExample": "The opposite of black is white",
+          "textExampleTranslate": "Противоположность черного есть белое",
+          "id": 434,
+          "word": "opposite",
+          "wordTranslate": "напротив"
+        },
+        {
+          "audioExample": "files/22_0436_example.mp3",
+          "textExample": "I received a present on my birthday",
+          "textExampleTranslate": "Я получил подарок на мой день рождения",
+          "id": 436,
+          "word": "receive",
+          "wordTranslate": "получать"
+        },
+        {
+          "audioExample": "files/22_0437_example.mp3",
+          "textExample": "He was given a reward for his excellent performance",
+          "textExampleTranslate": "Он получил награду за отличную работу",
+          "id": 437,
+          "word": "reward",
+          "wordTranslate": "награда"
+        },
+        {
+          "audioExample": "files/22_0438_example.mp3",
+          "textExample": "Please set the dice down on the table",
+          "textExampleTranslate": "Пожалуйста, поставьте кости на стол",
+          "id": 438,
+          "word": "set",
+          "wordTranslate": "набор"
+        },
+        {
+          "audioExample": "files/22_0439_example.mp3",
+          "textExample": "The men tried to steal money from the bank",
+          "textExampleTranslate": "Мужчины пытались украсть деньги из банка",
+          "id": 439,
+          "word": "steal",
+          "wordTranslate": "украсть"
+        },
+        {
+          "audioExample": "files/23_0441_example.mp3",
+          "textExample": "He advanced across the bridge slowly",
+          "textExampleTranslate": "Он медленно продвигался через мост",
+          "id": 441,
+          "word": "advance",
+          "wordTranslate": "вперед"
+        },
+        {
+          "audioExample": "files/23_0442_example.mp3",
+          "textExample": "Some athletes can play many sports very well",
+          "textExampleTranslate": "Некоторые спортсмены могут очень хорошо заниматься многими видами спорта",
+          "id": 442,
+          "word": "athlete",
+          "wordTranslate": "спортсмен"
+        },
+        {
+          "audioExample": "files/23_0443_example.mp3",
+          "textExample": "I’m not rich or poor; I’m average",
+          "textExampleTranslate": "Я не богат или не беден; я средний",
+          "id": 443,
+          "word": "average",
+          "wordTranslate": "средний"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_35",
+        "name": "Coastal Scene with Resting Riders",
+        "imageSrc": "level1/coastal.jpg",
+        "cutSrc": "level1/cut/coastal.jpg",
+        "author": "ASSELYN, Jan",
+        "year": "1652"
+      },
+      "words": [
+        {
+          "audioExample": "files/23_0444_example.mp3",
+          "textExample": "Their behavior was good this semester. They didn’t cause trouble",
+          "textExampleTranslate": "Их поведение было хорошим в этом семестре. Они не доставляли хлопот",
+          "id": 444,
+          "word": "behavior",
+          "wordTranslate": "поведение"
+        },
+        {
+          "audioExample": "files/23_0445_example.mp3",
+          "textExample": "The little girl was hiding behind a tree",
+          "textExampleTranslate": "Маленькая девочка пряталась за деревом",
+          "id": 445,
+          "word": "behind",
+          "wordTranslate": "позади"
+        },
+        {
+          "audioExample": "files/23_0446_example.mp3",
+          "textExample": "I took a P.E. course in school this year",
+          "textExampleTranslate": "В этом году я прошел курс обучения в школе",
+          "id": 446,
+          "word": "course",
+          "wordTranslate": "курс"
+        },
+        {
+          "audioExample": "files/23_0448_example.mp3",
+          "textExample": "The two shoes matched. They looked the same",
+          "textExampleTranslate": "Две туфли совпали. Они выглядели одинаково",
+          "id": 448,
+          "word": "match",
+          "wordTranslate": "матч"
+        },
+        {
+          "audioExample": "files/23_0449_example.mp3",
+          "textExample": "Julie is the newest member of our team",
+          "textExampleTranslate": "Джули - самый новый член нашей команды",
+          "id": 449,
+          "word": "member",
+          "wordTranslate": "член"
+        },
+        {
+          "audioExample": "files/23_0450_example.mp3",
+          "textExample": "I made a mental picture of the room",
+          "textExampleTranslate": "Я сделал мысленную картину комнаты",
+          "id": 450,
+          "word": "mental",
+          "wordTranslate": "психического"
+        },
+        {
+          "audioExample": "files/23_0451_example.mp3",
+          "textExample": "One passenger was standing near the subway train",
+          "textExampleTranslate": "Один пассажир стоял возле поезда метро",
+          "id": 451,
+          "word": "passenger",
+          "wordTranslate": "пассажир"
+        },
+        {
+          "audioExample": "files/23_0452_example.mp3",
+          "textExample": "John has a bad personality",
+          "textExampleTranslate": "У Джона плохая личность",
+          "id": 452,
+          "word": "personality",
+          "wordTranslate": "личность"
+        },
+        {
+          "audioExample": "files/23_0453_example.mp3",
+          "textExample": "William Shakespeare wrote many poems",
+          "textExampleTranslate": "Уильям Шекспир написал много стихов",
+          "id": 453,
+          "word": "poem",
+          "wordTranslate": "стихотворение"
+        },
+        {
+          "audioExample": "files/23_0454_example.mp3",
+          "textExample": "The flag was hanging from the flag pole",
+          "textExampleTranslate": "Флаг висел на флагштоке",
+          "id": 454,
+          "word": "pole",
+          "wordTranslate": "столб"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_36",
+        "name": "Italianate Landscape with a River and an Arched Bridge",
+        "imageSrc": "level1/italiana.jpg",
+        "cutSrc": "level1/cut/italiana.jpg",
+        "author": "ASSELYN, Jan",
+        "year": "1648"
+      },
+      "words": [
+        {
+          "audioExample": "files/23_0455_example.mp3",
+          "textExample": "I removed the nail from the board",
+          "textExampleTranslate": "Я снял гвоздь с доски",
+          "id": 455,
+          "word": "remove",
+          "wordTranslate": "удалить"
+        },
+        {
+          "audioExample": "files/23_0457_example.mp3",
+          "textExample": "The hunter raised his gun to shoot at the target",
+          "textExampleTranslate": "Охотник поднял ружье, чтобы выстрелить в цель",
+          "id": 457,
+          "word": "shoot",
+          "wordTranslate": "стрелять"
+        },
+        {
+          "audioExample": "files/23_0458_example.mp3",
+          "textExample": "The alarm clock sounded and woke us all up",
+          "textExampleTranslate": "Прозвучал будильник и разбудил нас всех",
+          "id": 458,
+          "word": "sound",
+          "wordTranslate": "звук"
+        },
+        {
+          "audioExample": "files/23_0459_example.mp3",
+          "textExample": "I love to swim in the ocean",
+          "textExampleTranslate": "Я люблю плавать в океане",
+          "id": 459,
+          "word": "swim",
+          "wordTranslate": "плавать"
+        },
+        {
+          "audioExample": "files/23_0460_example.mp3",
+          "textExample": "Mom cleaned the spider webs out of the garage",
+          "textExampleTranslate": "Мама убрала паутину из гаража",
+          "id": 460,
+          "word": "web",
+          "wordTranslate": "паутина"
+        },
+        {
+          "audioExample": "files/24_0461_example.mp3",
+          "textExample": "I saw a block of ice on the floor",
+          "textExampleTranslate": "Я видел кусок льда на полу",
+          "id": 461,
+          "word": "block",
+          "wordTranslate": "блок"
+        },
+        {
+          "audioExample": "files/24_0462_example.mp3",
+          "textExample": "My father was buried in his hometown when he died",
+          "textExampleTranslate": "Мой отец был похоронен в своем родном городе, когда он умер",
+          "id": 462,
+          "word": "bury",
+          "wordTranslate": "похоронить"
+        },
+        {
+          "audioExample": "files/24_0463_example.mp3",
+          "textExample": "The crowd all cheered when the home team won",
+          "textExampleTranslate": "Толпа всех приветствовала, когда победила хозяева",
+          "id": 463,
+          "word": "cheer",
+          "wordTranslate": "поболеть"
+        },
+        {
+          "audioExample": "files/24_0467_example.mp3",
+          "textExample": "Finishing high school was a major event in his life",
+          "textExampleTranslate": "Окончание средней школы было главным событием в его жизни",
+          "id": 467,
+          "word": "event",
+          "wordTranslate": "событие"
+        },
+        {
+          "audioExample": "files/24_0468_example.mp3",
+          "textExample": "You should exercise every day",
+          "textExampleTranslate": "Ты должен заниматься каждый день",
+          "id": 468,
+          "word": "exercise",
+          "wordTranslate": "упражнение"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_37",
+        "name": "Italianate Landscape with Peasants and Animals Fording a River",
+        "imageSrc": "level1/italianb.jpg",
+        "cutSrc": "level1/cut/italianb.jpg",
+        "author": "ASSELYN, Jan",
+        "year": "1640-45"
+      },
+      "words": [
+        {
+          "audioExample": "files/24_0470_example.mp3",
+          "textExample": "We followed a guide at the park",
+          "textExampleTranslate": "Мы следовали за гидом в парке",
+          "id": 470,
+          "word": "guide",
+          "wordTranslate": "руководство"
+        },
+        {
+          "audioExample": "files/24_0471_example.mp3",
+          "textExample": "His only problem is a lack of money",
+          "textExampleTranslate": "Его единственная проблема - нехватка денег",
+          "id": 471,
+          "word": "lack",
+          "wordTranslate": "отсутствие"
+        },
+        {
+          "audioExample": "files/24_0472_example.mp3",
+          "textExample": "He will perform a song for the class",
+          "textExampleTranslate": "Он исполнит песню для класса",
+          "id": 472,
+          "word": "perform",
+          "wordTranslate": "выполнить"
+        },
+        {
+          "audioExample": "files/24_0473_example.mp3",
+          "textExample": "They put pressure on him to change his mind",
+          "textExampleTranslate": "Они заставляют его передумать",
+          "id": 473,
+          "word": "pressure",
+          "wordTranslate": "давление"
+        },
+        {
+          "audioExample": "files/24_0476_example.mp3",
+          "textExample": "Mary is a smart student",
+          "textExampleTranslate": "Мария умная ученица",
+          "id": 476,
+          "word": "smart",
+          "wordTranslate": "умный"
+        },
+        {
+          "audioExample": "files/24_0477_example.mp3",
+          "textExample": "She struck the other girl in the face",
+          "textExampleTranslate": "Она ударила другую девушку по лицу",
+          "id": 477,
+          "word": "strike",
+          "wordTranslate": "забастовка"
+        },
+        {
+          "audioExample": "files/24_0478_example.mp3",
+          "textExample": "Everyone at work supports the new plan",
+          "textExampleTranslate": "Все на работе поддерживают новый план",
+          "id": 478,
+          "word": "support",
+          "wordTranslate": "служба поддержки"
+        },
+        {
+          "audioExample": "files/24_0480_example.mp3",
+          "textExample": "If we unite, we can finish our project faster",
+          "textExampleTranslate": "Если мы объединимся, мы сможем завершить наш проект быстрее",
+          "id": 480,
+          "word": "unite",
+          "wordTranslate": "объединить"
+        },
+        {
+          "audioExample": "files/25_0481_example.mp3",
+          "textExample": "Most people associate birthday parties with having fun",
+          "textExampleTranslate": "У большинства людей дни рождения ассоциируются с весельем",
+          "id": 481,
+          "word": "associate",
+          "wordTranslate": "ассоциировать"
+        },
+        {
+          "audioExample": "files/25_0482_example.mp3",
+          "textExample": "Keeping our environment clean is important to our health",
+          "textExampleTranslate": "Поддержание нашей окружающей среды в чистоте важно для нашего здоровья",
+          "id": 482,
+          "word": "environment",
+          "wordTranslate": "окружающая обстановка"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_38",
+        "name": "Landscape with Frozen River",
+        "imageSrc": "level1/landscap_2.jpg",
+        "cutSrc": "level1/cut/landscap_2.jpg",
+        "author": "AVERCAMP, Barend",
+        "year": "1655"
+      },
+      "words": [
+        {
+          "audioExample": "files/25_0483_example.mp3",
+          "textExample": "We have only one factory in our town",
+          "textExampleTranslate": "У нас только один завод в нашем городе",
+          "id": 483,
+          "word": "factory",
+          "wordTranslate": "фабрика"
+        },
+        {
+          "audioExample": "files/25_0484_example.mp3",
+          "textExample": "The cell phone has many features",
+          "textExampleTranslate": "У мобильного телефона много функций",
+          "id": 484,
+          "word": "feature",
+          "wordTranslate": "характерная черта"
+        },
+        {
+          "audioExample": "files/25_0485_example.mp3",
+          "textExample": "I have never experienced an instance of hate. Have you?",
+          "textExampleTranslate": "Я никогда не испытывал ненависти. А ты?",
+          "id": 485,
+          "word": "instance",
+          "wordTranslate": "пример"
+        },
+        {
+          "audioExample": "files/25_0486_example.mp3",
+          "textExample": "The whole family was involved in playing the game",
+          "textExampleTranslate": "Вся семья была вовлечена в игру",
+          "id": 486,
+          "word": "involve",
+          "wordTranslate": "включать"
+        },
+        {
+          "audioExample": "files/25_0487_example.mp3",
+          "textExample": "The doctor gave me medicine for my cold",
+          "textExampleTranslate": "Доктор дал мне лекарство от простуды",
+          "id": 487,
+          "word": "medicine",
+          "wordTranslate": "лекарство"
+        },
+        {
+          "audioExample": "files/25_0490_example.mp3",
+          "textExample": "In one period in Europe, there were many knights",
+          "textExampleTranslate": "За один период в Европе было много рыцарей",
+          "id": 490,
+          "word": "period",
+          "wordTranslate": "период"
+        },
+        {
+          "audioExample": "files/25_0491_example.mp3",
+          "textExample": "Billions of people populate the Earth",
+          "textExampleTranslate": "Миллиарды людей населяют Землю",
+          "id": 491,
+          "word": "populate",
+          "wordTranslate": "заселить"
+        },
+        {
+          "audioExample": "files/25_0492_example.mp3",
+          "textExample": "This tree produces apples every year",
+          "textExampleTranslate": "Это дерево производит яблоки каждый год",
+          "id": 492,
+          "word": "produce",
+          "wordTranslate": "производить"
+        },
+        {
+          "audioExample": "files/25_0493_example.mp3",
+          "textExample": "I saw a range of cars to choose from",
+          "textExampleTranslate": "Я видел целый ряд автомобилей на выбор",
+          "id": 493,
+          "word": "range",
+          "wordTranslate": "спектр"
+        },
+        {
+          "audioExample": "files/25_0494_example.mp3",
+          "textExample": "I recognized an old friend from many years ago",
+          "textExampleTranslate": "Я узнал старого друга много лет назад",
+          "id": 494,
+          "word": "recognize",
+          "wordTranslate": "признают"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_39",
+        "name": "Ice Landscape",
+        "imageSrc": "level1/ice_land.jpg",
+        "cutSrc": "level1/cut/ice_land.jpg",
+        "author": "AVERCAMP, Hendrick",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/25_0495_example.mp3",
+          "textExample": "Our regular lunch time is around noon",
+          "textExampleTranslate": "Мы регулярно обедаем около полудня",
+          "id": 495,
+          "word": "regular",
+          "wordTranslate": "стабильный"
+        },
+        {
+          "audioExample": "files/25_0496_example.mp3",
+          "textExample": "The sign indicated that today would be a bad day",
+          "textExampleTranslate": "Знак указывает, что сегодня будет плохой день",
+          "id": 496,
+          "word": "sign",
+          "wordTranslate": "подписать"
+        },
+        {
+          "audioExample": "files/25_0497_example.mp3",
+          "textExample": "The tip of his pen was very sharp",
+          "textExampleTranslate": "Кончик его ручки был очень острым",
+          "id": 497,
+          "word": "tip",
+          "wordTranslate": "подсказка"
+        },
+        {
+          "audioExample": "files/25_0498_example.mp3",
+          "textExample": "Marriage is a tradition all over the world",
+          "textExampleTranslate": "Брак - это традиция во всем мире",
+          "id": 498,
+          "word": "tradition",
+          "wordTranslate": "традиция"
+        },
+        {
+          "audioExample": "files/25_0499_example.mp3",
+          "textExample": "Please take out the trash; it smells bad",
+          "textExampleTranslate": "Пожалуйста, выньте мусор; он плохо пахнет",
+          "id": 499,
+          "word": "trash",
+          "wordTranslate": "мусор"
+        },
+        {
+          "audioExample": "files/25_0500_example.mp3",
+          "textExample": "The door was as wide as my arms",
+          "textExampleTranslate": "Дверь была такая же широкая, как мои руки",
+          "id": 500,
+          "word": "wide",
+          "wordTranslate": "широкий"
+        },
+        {
+          "audioExample": "files/26_0503_example.mp3",
+          "textExample": "His work got the attention of two of his co-workers",
+          "textExampleTranslate": "Его работа привлекла внимание двух его сотрудников",
+          "id": 503,
+          "word": "attention",
+          "wordTranslate": "внимание"
+        },
+        {
+          "audioExample": "files/26_0504_example.mp3",
+          "textExample": "The magnet attracted the metal",
+          "textExampleTranslate": "Магнит притягивал металл",
+          "id": 504,
+          "word": "attract",
+          "wordTranslate": "привлечь"
+        },
+        {
+          "audioExample": "files/26_0505_example.mp3",
+          "textExample": "The girls climbed to the top of the mountain",
+          "textExampleTranslate": "Девчонки забрались на вершину горы",
+          "id": 505,
+          "word": "climb",
+          "wordTranslate": "подняться"
+        },
+        {
+          "audioExample": "files/26_0506_example.mp3",
+          "textExample": "A small amount of water dropped from the bottle",
+          "textExampleTranslate": "из бутылки выпало небольшое количество воды",
+          "id": 506,
+          "word": "drop",
+          "wordTranslate": "падение"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_40",
+        "name": "Arabs on Horseback",
+        "imageSrc": "level1/arabs.jpg",
+        "cutSrc": "level1/cut/arabs.jpg",
+        "author": "AZEGLIO, Massimo Taparelli, Marquis d'",
+        "year": "1840"
+      },
+      "words": [
+        {
+          "audioExample": "files/26_0508_example.mp3",
+          "textExample": "The escalator is further than I thought",
+          "textExampleTranslate": "Эскалатор дальше, чем я думал",
+          "id": 508,
+          "word": "further",
+          "wordTranslate": "дальше"
+        },
+        {
+          "audioExample": "files/26_0510_example.mp3",
+          "textExample": "The balls maintain constant movement",
+          "textExampleTranslate": "Шарики поддерживают постоянное движение",
+          "id": 510,
+          "word": "maintain",
+          "wordTranslate": "поддерживать"
+        },
+        {
+          "audioExample": "files/26_0512_example.mp3",
+          "textExample": "It’s good to stay active; otherwise, you’ll gain weight",
+          "textExampleTranslate": "Хорошо быть активным, иначе ты наберешь вес",
+          "id": 512,
+          "word": "otherwise",
+          "wordTranslate": "в противном случае"
+        },
+        {
+          "audioExample": "files/26_0513_example.mp3",
+          "textExample": "Biking is good for your physical health",
+          "textExampleTranslate": "Езда на велосипеде полезна для вашего физического здоровья",
+          "id": 513,
+          "word": "physical",
+          "wordTranslate": "физический"
+        },
+        {
+          "audioExample": "files/26_0514_example.mp3",
+          "textExample": "My teacher proved the answer on the board",
+          "textExampleTranslate": "Мой учитель доказал ответ на доске",
+          "id": 514,
+          "word": "prove",
+          "wordTranslate": "доказать"
+        },
+        {
+          "audioExample": "files/26_0515_example.mp3",
+          "textExample": "James reacted badly to the news",
+          "textExampleTranslate": "Джеймс плохо отреагировал на новости",
+          "id": 515,
+          "word": "react",
+          "wordTranslate": "реагируют"
+        },
+        {
+          "audioExample": "files/26_0517_example.mp3",
+          "textExample": "The whiteboard is situated between the two men",
+          "textExampleTranslate": "Доска расположена между двумя мужчинами",
+          "id": 517,
+          "word": "situated",
+          "wordTranslate": "расположенный"
+        },
+        {
+          "audioExample": "files/26_0518_example.mp3",
+          "textExample": "Society expects people to be good and honest",
+          "textExampleTranslate": "Общество ожидает, что люди будут хорошими и честными",
+          "id": 518,
+          "word": "society",
+          "wordTranslate": "общество"
+        },
+        {
+          "audioExample": "files/26_0519_example.mp3",
+          "textExample": "This older model TV is below our store’s standards",
+          "textExampleTranslate": "Эта старая модель телевизора не соответствует стандартам нашего магазина",
+          "id": 519,
+          "word": "standard",
+          "wordTranslate": "стандарт"
+        },
+        {
+          "audioExample": "files/26_0520_example.mp3",
+          "textExample": "He suggested that we go to see his boss",
+          "textExampleTranslate": "Он предложил пойти к его боссу",
+          "id": 520,
+          "word": "suggest",
+          "wordTranslate": "предложить"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_41",
+        "name": "Ships in Distress off a Rocky Coast",
+        "imageSrc": "level1/distress.jpg",
+        "cutSrc": "level1/cut/distress.jpg",
+        "author": "BACKHUYSEN, Ludolf",
+        "year": "1667"
+      },
+      "words": [
+        {
+          "audioExample": "files/27_0522_example.mp3",
+          "textExample": "The boy took a big bite of his hamburger",
+          "textExampleTranslate": "Мальчик откусил гамбургер",
+          "id": 522,
+          "word": "bite",
+          "wordTranslate": "укусить"
+        },
+        {
+          "audioExample": "files/27_0523_example.mp3",
+          "textExample": "I stayed on the southern coast of Australia",
+          "textExampleTranslate": "Я остался на южном побережье Австралии",
+          "id": 523,
+          "word": "coast",
+          "wordTranslate": "побережье"
+        },
+        {
+          "audioExample": "files/27_0525_example.mp3",
+          "textExample": "Not many plants grow in the desert",
+          "textExampleTranslate": "В пустыне мало растений",
+          "id": 525,
+          "word": "desert",
+          "wordTranslate": "пустыня"
+        },
+        {
+          "audioExample": "files/27_0526_example.mp3",
+          "textExample": "Swimming is an effective way to stay healthy",
+          "textExampleTranslate": "Плавание - эффективный способ оставаться здоровым",
+          "id": 526,
+          "word": "effective",
+          "wordTranslate": "эффективный"
+        },
+        {
+          "audioExample": "files/27_0527_example.mp3",
+          "textExample": "The doctor examined my eyes today",
+          "textExampleTranslate": "Доктор осмотрел мои глаза сегодня",
+          "id": 527,
+          "word": "examine",
+          "wordTranslate": "исследовать"
+        },
+        {
+          "audioExample": "files/27_0529_example.mp3",
+          "textExample": "I couldn’t figure out what he wanted me to do",
+          "textExampleTranslate": "Я не мог понять, что он от меня хотел",
+          "id": 529,
+          "word": "figure out",
+          "wordTranslate": "выяснять"
+        },
+        {
+          "audioExample": "files/27_0530_example.mp3",
+          "textExample": "Dave received many gifts for Christmas",
+          "textExampleTranslate": "Дейв получил много подарков на Рождество",
+          "id": 530,
+          "word": "gift",
+          "wordTranslate": "подарок"
+        },
+        {
+          "audioExample": "files/27_0531_example.mp3",
+          "textExample": "After playing all day long, he was filled with hunger",
+          "textExampleTranslate": "После целого дня игры он был полон голода",
+          "id": 531,
+          "word": "hunger",
+          "wordTranslate": "голод"
+        },
+        {
+          "audioExample": "files/27_0532_example.mp3",
+          "textExample": "Sally imagined herself winning lots of money",
+          "textExampleTranslate": "Салли представила, что выигрывает много денег",
+          "id": 532,
+          "word": "imagine",
+          "wordTranslate": "представить"
+        },
+        {
+          "audioExample": "files/27_0534_example.mp3",
+          "textExample": "The question was a puzzle to him",
+          "textExampleTranslate": "Вопрос был для него загадкой",
+          "id": 534,
+          "word": "puzzle",
+          "wordTranslate": "головоломка"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_42",
+        "name": "A Fishing Pink",
+        "imageSrc": "level1/fishing.jpg",
+        "cutSrc": "level1/cut/fishing.jpg",
+        "author": "BACKHUYSEN, Ludolf",
+        "year": "1680"
+      },
+      "words": [
+        {
+          "audioExample": "files/27_0535_example.mp3",
+          "textExample": "I think typing on a keyboard is quite easy",
+          "textExampleTranslate": "Я думаю, что набирать текст на клавиатуре довольно просто",
+          "id": 535,
+          "word": "quite",
+          "wordTranslate": "довольно"
+        },
+        {
+          "audioExample": "files/27_0537_example.mp3",
+          "textExample": "Please choose a specific place on the map",
+          "textExampleTranslate": "Пожалуйста, выберите конкретное место на карте",
+          "id": 537,
+          "word": "specific",
+          "wordTranslate": "конкретный"
+        },
+        {
+          "audioExample": "files/27_0539_example.mp3",
+          "textExample": "I took a tour of Asia and Europe",
+          "textExampleTranslate": "Я взял тур по Азии и Европе",
+          "id": 539,
+          "word": "tour",
+          "wordTranslate": "тур"
+        },
+        {
+          "audioExample": "files/27_0540_example.mp3",
+          "textExample": "Ken took a trip to the city yesterday",
+          "textExampleTranslate": "Кен отправился в город вчера",
+          "id": 540,
+          "word": "trip",
+          "wordTranslate": "поездка"
+        },
+        {
+          "audioExample": "files/28_0541_example.mp3",
+          "textExample": "My brother is in a rock band",
+          "textExampleTranslate": "Мой брат в рок-группе",
+          "id": 541,
+          "word": "band",
+          "wordTranslate": "группа"
+        },
+        {
+          "audioExample": "files/28_0543_example.mp3",
+          "textExample": "I think the Internet is boring",
+          "textExampleTranslate": "Я думаю, что Интернет скучен",
+          "id": 543,
+          "word": "boring",
+          "wordTranslate": "скучно"
+        },
+        {
+          "audioExample": "files/28_0545_example.mp3",
+          "textExample": "The long driveway led us to their new house",
+          "textExampleTranslate": "Долгий путь привел нас к их новому дому",
+          "id": 545,
+          "word": "driveway",
+          "wordTranslate": "подъездные пути"
+        },
+        {
+          "audioExample": "files/28_0546_example.mp3",
+          "textExample": "The boy cleaned up the garbage around his house",
+          "textExampleTranslate": "Мальчик убрал мусор вокруг своего дома",
+          "id": 546,
+          "word": "garbage",
+          "wordTranslate": "мусор"
+        },
+        {
+          "audioExample": "files/28_0547_example.mp3",
+          "textExample": "My favorite musical instrument is the piano",
+          "textExampleTranslate": "Мой любимый музыкальный инструмент - пианино",
+          "id": 547,
+          "word": "instrument",
+          "wordTranslate": "инструмент"
+        },
+        {
+          "audioExample": "files/28_0548_example.mp3",
+          "textExample": "My mom makes a list of groceries to buy",
+          "textExampleTranslate": "Моя мама составляет список покупок",
+          "id": 548,
+          "word": "list",
+          "wordTranslate": "список"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_43",
+        "name": "Shipping by the Dutch Coast",
+        "imageSrc": "level1/shipping_1.jpg",
+        "cutSrc": "level1/cut/shipping_1.jpg",
+        "author": "BACKHUYSEN, Ludolf",
+        "year": "XVII century"
+      },
+      "words": [
+        {
+          "audioExample": "files/28_0550_example.mp3",
+          "textExample": "I left a message for you in the envelope",
+          "textExampleTranslate": "Я оставил тебе сообщение в конверте",
+          "id": 550,
+          "word": "message",
+          "wordTranslate": "сообщение"
+        },
+        {
+          "audioExample": "files/28_0551_example.mp3",
+          "textExample": "Did you notice the view?",
+          "textExampleTranslate": "Вы заметили вид?",
+          "id": 551,
+          "word": "notice",
+          "wordTranslate": "уведомление"
+        },
+        {
+          "audioExample": "files/28_0552_example.mp3",
+          "textExample": "My grandfather owns that house",
+          "textExampleTranslate": "Мой дедушка владеет этим домом",
+          "id": 552,
+          "word": "own",
+          "wordTranslate": "своя"
+        },
+        {
+          "audioExample": "files/28_0553_example.mp3",
+          "textExample": "She predicted that I would get married next year",
+          "textExampleTranslate": "Она предсказала, что я выйду замуж в следующем году",
+          "id": 553,
+          "word": "predict",
+          "wordTranslate": "предсказать"
+        },
+        {
+          "audioExample": "files/28_0554_example.mp3",
+          "textExample": "Mike’s science professor knows a lot about physics",
+          "textExampleTranslate": "Профессор Майка много знает о физике",
+          "id": 554,
+          "word": "professor",
+          "wordTranslate": "профессор"
+        },
+        {
+          "audioExample": "files/28_0555_example.mp3",
+          "textExample": "Nancy rushed to finish her homework",
+          "textExampleTranslate": "Нэнси поспешила закончить домашнее задание",
+          "id": 555,
+          "word": "rush",
+          "wordTranslate": "порыв"
+        },
+        {
+          "audioExample": "files/28_0556_example.mp3",
+          "textExample": "What is your class schedule for today?",
+          "textExampleTranslate": "Какое у тебя расписание занятий на сегодня?",
+          "id": 556,
+          "word": "schedule",
+          "wordTranslate": "график"
+        },
+        {
+          "audioExample": "files/28_0557_example.mp3",
+          "textExample": "Jimmy shared his apple with me",
+          "textExampleTranslate": "Джимми поделился со мной своим яблоком",
+          "id": 557,
+          "word": "share",
+          "wordTranslate": "доля"
+        },
+        {
+          "audioExample": "files/28_0558_example.mp3",
+          "textExample": "A large screen was on the stage",
+          "textExampleTranslate": "Большой экран был на сцене",
+          "id": 558,
+          "word": "stage",
+          "wordTranslate": "сцена"
+        },
+        {
+          "audioExample": "files/28_0559_example.mp3",
+          "textExample": "Did that storm wake you up last night?",
+          "textExampleTranslate": "Этот шторм разбудил тебя прошлой ночью?",
+          "id": 559,
+          "word": "storm",
+          "wordTranslate": "буря"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_44",
+        "name": "View from the Nieuwe Maas River towards the City of Vlaardingen",
+        "imageSrc": "level1/viewvlaa.jpg",
+        "cutSrc": "level1/cut/viewvlaa.jpg",
+        "author": "BACKHUYSEN, Ludolf",
+        "year": "1680s"
+      },
+      "words": [
+        {
+          "audioExample": "files/28_0560_example.mp3",
+          "textExample": "Within the box, there was a pizza",
+          "textExampleTranslate": "Внутри коробки была пицца",
+          "id": 560,
+          "word": "within",
+          "wordTranslate": "в пределах"
+        },
+        {
+          "audioExample": "files/29_0562_example.mp3",
+          "textExample": "We both compromised about the game we decided to play",
+          "textExampleTranslate": "Мы оба пошли на компромисс по поводу игры, в которую решили играть",
+          "id": 562,
+          "word": "compromise",
+          "wordTranslate": "компромисс"
+        },
+        {
+          "audioExample": "files/29_0564_example.mp3",
+          "textExample": "I like sky-diving from an airplane",
+          "textExampleTranslate": "Мне нравится скайдайвинг с самолета",
+          "id": 564,
+          "word": "dive",
+          "wordTranslate": "погружение"
+        },
+        {
+          "audioExample": "files/29_0565_example.mp3",
+          "textExample": "The fragile glassware was carefully packed into boxes",
+          "textExampleTranslate": "Хрупкая стеклянная посуда была тщательно упакована в коробки",
+          "id": 565,
+          "word": "fragile",
+          "wordTranslate": "хрупкий"
+        },
+        {
+          "audioExample": "files/29_0566_example.mp3",
+          "textExample": "The machine can divide the book in half",
+          "textExampleTranslate": "Машина может разделить книгу пополам",
+          "id": 566,
+          "word": "half",
+          "wordTranslate": "половина"
+        },
+        {
+          "audioExample": "files/29_0567_example.mp3",
+          "textExample": "Everyone who met her found her innocence to be charming",
+          "textExampleTranslate": "Все, кто встречал ее, находили ее невинность очаровательной",
+          "id": 567,
+          "word": "innocence",
+          "wordTranslate": "невинность"
+        },
+        {
+          "audioExample": "files/29_0568_example.mp3",
+          "textExample": "I will lead you to the right place",
+          "textExampleTranslate": "Я приведу вас в нужное место",
+          "id": 568,
+          "word": "lead",
+          "wordTranslate": "вести"
+        },
+        {
+          "audioExample": "files/29_0572_example.mp3",
+          "textExample": "The amount of homework her teacher assigned has overwhelmed her",
+          "textExampleTranslate": "Количество домашних заданий, которые назначил ее учитель, ошеломило ее",
+          "id": 572,
+          "word": "overwhelm",
+          "wordTranslate": "нападает"
+        },
+        {
+          "audioExample": "files/29_0578_example.mp3",
+          "textExample": "Speeding is the cause of most car accidents",
+          "textExampleTranslate": "Ускорение является причиной большинства автомобильных аварий",
+          "id": 578,
+          "word": "speed",
+          "wordTranslate": "скорость"
+        },
+        {
+          "audioExample": "files/29_0580_example.mp3",
+          "textExample": "It was just the usual people who came",
+          "textExampleTranslate": "Это были просто обычные люди, которые пришли",
+          "id": 580,
+          "word": "usual",
+          "wordTranslate": "обычный"
+        }
+      ]
+    },
+    {
+      "levelData": {
+        "id": "1_45",
+        "name": "Dutch Vessels off a Coastline on a Breezy Day",
+        "imageSrc": "level1/vessels1.jpg",
+        "cutSrc": "level1/cut/vessels1.jpg",
+        "author": "BACKHUYSEN, Ludolf",
+        "year": "1680"
+      },
+      "words": [
+        {
+          "audioExample": "files/30_0581_example.mp3",
+          "textExample": "He straightened the sign that was above the crowd",
+          "textExampleTranslate": "Он поправил знак, который был над толпой",
+          "id": 581,
+          "word": "above",
+          "wordTranslate": "над"
+        },
+        {
+          "audioExample": "files/30_0582_example.mp3",
+          "textExample": "The blue car drove on ahead of us",
+          "textExampleTranslate": "Синяя машина ехала впереди нас",
+          "id": 582,
+          "word": "ahead",
+          "wordTranslate": "вперед"
+        },
+        {
+          "audioExample": "files/30_0586_example.mp3",
+          "textExample": "It is common for snow to fall in the winter",
+          "textExampleTranslate": "Зимой выпадает снег",
+          "id": 586,
+          "word": "common",
+          "wordTranslate": "общий"
+        },
+        {
+          "audioExample": "files/30_0587_example.mp3",
+          "textExample": "These designer shoes cost more than the regular ones",
+          "textExampleTranslate": "Эти дизайнерские туфли стоят дороже обычных",
+          "id": 587,
+          "word": "cost",
+          "wordTranslate": "стоимость"
+        },
+        {
+          "audioExample": "files/30_0588_example.mp3",
+          "textExample": "She demonstrated her plan to her co-workers",
+          "textExampleTranslate": "Она продемонстрировала свой план своим сотрудникам",
+          "id": 588,
+          "word": "demonstrate",
+          "wordTranslate": "продемонстрировать"
+        },
+        {
+          "audioExample": "files/30_0589_example.mp3",
+          "textExample": "Each of my sisters has a different hair style",
+          "textExampleTranslate": "У каждой из моих сестер разные прически",
+          "id": 589,
+          "word": "different",
+          "wordTranslate": "другой"
+        },
+        {
+          "audioExample": "files/30_0590_example.mp3",
+          "textExample": "He used the pictures as evidence that UFOs are real",
+          "textExampleTranslate": "Он использовал фотографии в качестве доказательства того, что НЛО реальны",
+          "id": 590,
+          "word": "evidence",
+          "wordTranslate": "доказательство"
+        },
+        {
+          "audioExample": "files/30_0591_example.mp3",
+          "textExample": "A courtroom should be a place of honesty",
+          "textExampleTranslate": "Зал суда должен быть местом честности",
+          "id": 591,
+          "word": "honesty",
+          "wordTranslate": "честность"
+        },
+        {
+          "audioExample": "files/30_0593_example.mp3",
+          "textExample": "She chose to live an independent life in the country",
+          "textExampleTranslate": "Она решила жить независимой жизнью в стране",
+          "id": 593,
+          "word": "independent",
+          "wordTranslate": "независимый"
+        },
+        {
+          "audioExample": "files/30_0594_example.mp3",
+          "textExample": "The inside of the box was empty",
+          "textExampleTranslate": "Внутри коробки было пусто",
+          "id": 594,
+          "word": "inside",
+          "wordTranslate": "внутри"
+        }
+      ]
+    }
+  ],
+  "roundsCount": 45
+}

--- a/src/features/game/GameField.module.css
+++ b/src/features/game/GameField.module.css
@@ -1,3 +1,20 @@
 .field {
   background-color: var(--color-grey-300);
 }
+
+.row {
+  height: 3rem;
+  border-bottom: 1px solid var(--color-grey-500);
+}
+
+.word {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 1px solid var(--color-grey-500);
+  height: 100%;
+
+  cursor: pointer;
+  user-select: none;
+}

--- a/src/features/game/GameField.module.css
+++ b/src/features/game/GameField.module.css
@@ -1,0 +1,3 @@
+.field {
+  background-color: var(--color-grey-300);
+}

--- a/src/features/game/GameField.ts
+++ b/src/features/game/GameField.ts
@@ -1,0 +1,12 @@
+import Component from "../../shared/Component";
+
+import styles from "./GameField.module.css";
+
+export default class GameField extends Component {
+  constructor() {
+    super({
+      tag: "div",
+      className: styles.field,
+    });
+  }
+}

--- a/src/features/game/GameField.ts
+++ b/src/features/game/GameField.ts
@@ -1,12 +1,33 @@
 import Component from "../../shared/Component";
+import { div } from "../../ui/tags";
+
+import { WordData } from "./WordsContainer";
 
 import styles from "./GameField.module.css";
 
 export default class GameField extends Component {
+  private row: Component;
+
   constructor() {
     super({
       tag: "div",
       className: styles.field,
     });
+
+    this.row = div({ className: styles.row });
+    this.append(this.row);
+
+    // TODO: use observer pattern
+    window.addEventListener(
+      "move-word",
+      this.handler.bind(this) as (e: Event) => void,
+    );
+  }
+
+  handler(e: CustomEvent<WordData>) {
+    const card = div({ className: styles.word, text: e.detail.word });
+    card.getElement().style.width = `${e.detail.width.toString()}%`;
+
+    this.row.append(card);
   }
 }

--- a/src/features/game/WordsContainer.module.css
+++ b/src/features/game/WordsContainer.module.css
@@ -1,16 +1,17 @@
 .words {
-  display: flex;
-  align-items: center;
   background-color: var(--color-grey-50);
   box-shadow: var(--shadow-sm);
+  height: 3rem;
 }
 
 .word {
-  text-align: center;
-  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
   border: 1px solid var(--color-grey-500);
-  height: max-content;
-  padding: 0.5rem;
+  height: 100%;
+
   cursor: pointer;
   user-select: none;
 }

--- a/src/features/game/WordsContainer.module.css
+++ b/src/features/game/WordsContainer.module.css
@@ -1,0 +1,16 @@
+.words {
+  display: flex;
+  align-items: center;
+  background-color: var(--color-grey-50);
+  box-shadow: var(--shadow-sm);
+}
+
+.word {
+  text-align: center;
+  flex: 1;
+  border: 1px solid var(--color-grey-500);
+  height: max-content;
+  padding: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}

--- a/src/features/game/WordsContainer.ts
+++ b/src/features/game/WordsContainer.ts
@@ -3,6 +3,11 @@ import { div } from "../../ui/tags";
 
 import styles from "./WordsContainer.module.css";
 
+export type WordData = {
+  word: string;
+  width: number;
+};
+
 export default class WordsContainer extends Component {
   private words: Array<string> = [];
 
@@ -29,9 +34,31 @@ export default class WordsContainer extends Component {
         const card = div({ className: styles.word, text: word });
         card.getElement().style.width = `${this.calculateCardWidth(word).toString()}%`;
 
+        card.addListener("click", () => {
+          this.moveWord(word);
+        });
+
         return card;
       }),
     );
+  }
+
+  private moveWord(word: string) {
+    const index = this.words.indexOf(word);
+
+    this.words.splice(index, 1);
+
+    // TODO: use observer pattern
+    window.dispatchEvent(
+      new CustomEvent<WordData>("move-word", {
+        detail: {
+          word,
+          width: this.calculateCardWidth(word),
+        },
+      }),
+    );
+
+    this.updateWords();
   }
 
   private calculateCardWidth(word: string) {

--- a/src/features/game/WordsContainer.ts
+++ b/src/features/game/WordsContainer.ts
@@ -1,0 +1,23 @@
+import Component from "../../shared/Component";
+import { div } from "../../ui/tags";
+
+import styles from "./WordsContainer.module.css";
+
+export default class WordsContainer extends Component {
+  constructor(private sentence: string) {
+    super({
+      tag: "div",
+      className: styles.words,
+    });
+
+    this.configure();
+  }
+
+  private configure() {
+    const words = this.sentence
+      .split(" ")
+      .map((word) => div({ className: styles.word, text: word }));
+
+    this.appendChildren(words);
+  }
+}

--- a/src/features/game/WordsContainer.ts
+++ b/src/features/game/WordsContainer.ts
@@ -4,6 +4,8 @@ import { div } from "../../ui/tags";
 import styles from "./WordsContainer.module.css";
 
 export default class WordsContainer extends Component {
+  private words: Array<string> = [];
+
   constructor(private sentence: string) {
     super({
       tag: "div",
@@ -14,10 +16,26 @@ export default class WordsContainer extends Component {
   }
 
   private configure() {
-    const words = this.sentence
-      .split(" ")
-      .map((word) => div({ className: styles.word, text: word }));
+    this.words = this.sentence.split(" ").sort(() => Math.random() - 0.5);
 
-    this.appendChildren(words);
+    this.updateWords();
+  }
+
+  private updateWords() {
+    this.clear();
+
+    this.appendChildren(
+      this.words.map((word) => {
+        const card = div({ className: styles.word, text: word });
+        card.getElement().style.width = `${this.calculateCardWidth(word).toString()}%`;
+
+        return card;
+      }),
+    );
+  }
+
+  private calculateCardWidth(word: string) {
+    const totalCharacters = this.sentence.split(" ").join("").length;
+    return (word.length * 100) / totalCharacters;
   }
 }

--- a/src/pages/game/GamePage.module.css
+++ b/src/pages/game/GamePage.module.css
@@ -1,7 +1,10 @@
 .page {
   display: grid;
-  place-content: center;
+  grid-template-columns: 1fr;
+  grid-template-rows: 3fr auto;
+  row-gap: 2rem;
 
-  font-size: 2rem;
-  font-weight: 500;
+  width: 768px;
+  margin: 0 auto;
+  padding: 2rem;
 }

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -1,4 +1,8 @@
 import Component from "../../shared/Component";
+import GameField from "../../features/game/GameField";
+import WordsContainer from "../../features/game/WordsContainer";
+
+import wordsData from "../../../data/words.json";
 
 import styles from "./GamePage.module.css";
 
@@ -6,8 +10,17 @@ export default class GamePage extends Component {
   constructor() {
     super({
       tag: "main",
-      text: "GAME PAGE",
       className: styles.page,
     });
+    this.configure();
+  }
+
+  private configure() {
+    const gameField = new GameField();
+
+    // TEMP
+    const words = new WordsContainer(wordsData.rounds[0].words[0].textExample);
+
+    this.appendChildren([gameField, words]);
   }
 }


### PR DESCRIPTION
# What
The main game page features individual word cards, each representing a word from a given sentence.

# Why
Players will interact with these cards by clicking on them to sequentially move them to a result block, aiming to reconstruct the original sentence.

# How
- Broke down a provided sentence into individual words.
- Displayed cards in random order.
- Calculated card width based on word length.
- Dispatched custom events that move cards to the result block.

# Note
This current solution is adequate for now, but it may not be scalable as the application expands with numerous moving parts. It might be beneficial to explore design patterns at this stage.