### PR TITLE
fix: Change width calculation formula

### DIFF
--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -3,13 +3,12 @@ import type { Word } from "../features/game/types";
 const ROW_WIDTH = 728;
 const CONCAVE_WIDTH = 10;
 
-// take concave WIDTH into account in order to visually align narrow pieces like "a", "I", "at" etc
+// take concave width into account in order to visually align narrow pieces like "a", "I", "at" etc
 export function calculateCardWidthPixels(sentence: string, word: string) {
   const totalWords = sentence.split(" ").length;
   const totalCharacters = sentence.split(" ").join("").length;
 
-  // all pieces have the concave except for the first
-  const availableSpace = ROW_WIDTH - CONCAVE_WIDTH * (totalWords - 1);
+  const availableSpace = ROW_WIDTH - CONCAVE_WIDTH * totalWords;
 
   return (availableSpace * word.length) / totalCharacters + CONCAVE_WIDTH;
 }


### PR DESCRIPTION
## What was done
Adjusted the width of the fields to ensure consistency. The fields now maintain a constant width throughout the game.

## Reason for the change
The inconsistent field widths were visually disruptive and detracted from the player's enjoyment of the game.

## Implementation details
Modified the formula used to calculate card width.