### PR TITLE
feat: PZ-18 Add translation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+    />
     <title>Puzzle</title>
   </head>
   <body>

--- a/src/features/game/controls/GameControls.ts
+++ b/src/features/game/controls/GameControls.ts
@@ -2,7 +2,6 @@ import Component from "../../../shared/Component";
 import Button from "../../../ui/button/Button";
 import GameState from "../model/GameState";
 
-import { StageStatus } from "../types";
 import { Observer } from "../../../shared/Observer";
 
 import styles from "./GameControls.module.css";
@@ -39,15 +38,8 @@ export default class GameControls extends Component implements Observer {
   }
 
   updateFlowButton(gameState: GameState) {
-    const { status } = gameState.state.levels;
-
-    const isStageComplete = [
-      StageStatus.AUTOCOMPLETED,
-      StageStatus.CORRECT,
-    ].includes(status);
-
-    const text = isStageComplete ? "Continue" : "Check";
-    const callback = isStageComplete
+    const text = gameState.isStageCompleted() ? "Continue" : "Check";
+    const callback = gameState.isStageCompleted()
       ? gameState.startNextStage.bind(gameState)
       : gameState.verifyAnswer.bind(gameState);
 

--- a/src/features/game/hints/HintControls.module.css
+++ b/src/features/game/hints/HintControls.module.css
@@ -1,0 +1,5 @@
+.controls {
+  display: flex;
+  gap: 10px;
+  justify-content: end;
+}

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -25,7 +25,14 @@ export default class HintsControls extends Component implements Observer {
   }
 
   update(gameState: GameState): void {
-    const isTranslationShown = gameState.state.hints.settings.translation;
+    let isTranslationShown = gameState.state.hints.settings.translation;
+
+    if (gameState.isStageCompleted()) {
+      isTranslationShown = true;
+      this.translationButton.setAttribute("disabled", "");
+    } else {
+      this.translationButton.removeAttribute("disabled");
+    }
 
     const iconName = isTranslationShown
       ? "bi bi-lightbulb-off"

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -1,0 +1,39 @@
+import Component from "../../../shared/Component";
+import { Observer } from "../../../shared/Observer";
+import ButtonIcon from "../../../ui/button/ButtonIcon";
+import GameState from "../model/GameState";
+
+import styles from "./HintControls.module.css";
+
+// TODO: maybe use styled checkboxes instead of buttons
+export default class HintsControls extends Component implements Observer {
+  private translationButton: ButtonIcon;
+
+  // TODO: create settings type
+  // private currentSettings = {
+  //   translation: true,
+  // };
+
+  constructor() {
+    super({
+      tag: "div",
+      className: styles.controls,
+    });
+
+    this.translationButton = new ButtonIcon("bi bi-lightbulb", () => {});
+    this.append(this.translationButton);
+  }
+
+  update(gameState: GameState): void {
+    const isTranslationShown = gameState.state.hints.settings.translation;
+
+    const iconName = isTranslationShown
+      ? "bi bi-lightbulb-off"
+      : "bi bi-lightbulb";
+
+    this.translationButton.updateCallback(
+      gameState.toggleTranslationHint.bind(gameState),
+    );
+    this.translationButton.updateIcon(iconName);
+  }
+}

--- a/src/features/game/hints/TranslationHint.module.css
+++ b/src/features/game/hints/TranslationHint.module.css
@@ -1,4 +1,10 @@
 .translation {
   text-align: center;
   font-style: italic;
+
+  transition: filter 0.3s;
+}
+
+.blurred {
+  filter: blur(7px);
 }

--- a/src/features/game/hints/TranslationHint.module.css
+++ b/src/features/game/hints/TranslationHint.module.css
@@ -3,6 +3,7 @@
   font-style: italic;
 
   transition: filter 0.3s;
+  user-select: none;
 }
 
 .blurred {

--- a/src/features/game/hints/TranslationHint.ts
+++ b/src/features/game/hints/TranslationHint.ts
@@ -7,12 +7,18 @@ import styles from "./TranslationHint.module.css";
 export default class TranslationHint extends Component implements Observer {
   constructor() {
     super({
-      tag: "p",
+      tag: "div",
       className: styles.translation,
     });
   }
 
   update(gameState: GameState): void {
+    const isShown = gameState.state.hints.settings.translation;
+
+    if (isShown) {
+      this.removeClass(styles.blurred);
+    } else this.addClass(styles.blurred);
+
     this.setTextContent(gameState.state.hints.content.translation);
   }
 }

--- a/src/features/game/hints/TranslationHint.ts
+++ b/src/features/game/hints/TranslationHint.ts
@@ -15,7 +15,7 @@ export default class TranslationHint extends Component implements Observer {
   update(gameState: GameState): void {
     const isShown = gameState.state.hints.settings.translation;
 
-    if (isShown) {
+    if (isShown || gameState.isStageCompleted()) {
       this.removeClass(styles.blurred);
     } else this.addClass(styles.blurred);
 

--- a/src/features/game/hints/TranslationHint.ts
+++ b/src/features/game/hints/TranslationHint.ts
@@ -7,7 +7,7 @@ import styles from "./TranslationHint.module.css";
 export default class TranslationHint extends Component implements Observer {
   constructor() {
     super({
-      tag: "div",
+      tag: "p",
       className: styles.translation,
     });
   }

--- a/src/features/game/model/GameState.ts
+++ b/src/features/game/model/GameState.ts
@@ -32,7 +32,7 @@ function prepareState(round: number, stage: number): GameData {
     },
     hints: {
       content: { translation },
-      settings: { translation: true },
+      settings: { translation: false },
     },
   };
 }
@@ -114,5 +114,12 @@ export default class GameState extends State<GameData> {
 
   isFilled() {
     return this.state.content.assembleArea.every((item) => item);
+  }
+
+  toggleTranslationHint() {
+    this.state.hints.settings.translation =
+      !this.state.hints.settings.translation;
+
+    this.notifySubscribers();
   }
 }

--- a/src/features/game/model/GameState.ts
+++ b/src/features/game/model/GameState.ts
@@ -116,6 +116,12 @@ export default class GameState extends State<GameData> {
     return this.state.content.assembleArea.every((item) => item);
   }
 
+  isStageCompleted() {
+    return [StageStatus.AUTOCOMPLETED, StageStatus.CORRECT].includes(
+      this.state.levels.status,
+    );
+  }
+
   toggleTranslationHint() {
     this.state.hints.settings.translation =
       !this.state.hints.settings.translation;

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -6,6 +6,7 @@ import GameState from "../../features/game/model/GameState";
 import styles from "./GamePage.module.css";
 import GameControls from "../../features/game/controls/GameControls";
 import TranslationHint from "../../features/game/hints/TranslationHint";
+import HintsControls from "../../features/game/hints/HintControls";
 
 export default class GamePage extends Component {
   gameState: GameState;
@@ -22,19 +23,27 @@ export default class GamePage extends Component {
   }
 
   private configure() {
-    const translationHint = new TranslationHint();
     const gameField = new GameField();
     const words = new WordsContainer();
-    const controls = new GameControls();
+    const stageControls = new GameControls();
+    const hintControls = new HintsControls();
+    const translationHint = new TranslationHint();
 
-    this.gameState.subscribe(translationHint);
-    this.gameState.subscribe(gameField);
-    this.gameState.subscribe(words);
-    this.gameState.subscribe(controls);
+    const children = [
+      hintControls,
+      translationHint,
+      gameField,
+      words,
+      stageControls,
+    ];
+
+    children.forEach((child) => {
+      this.gameState.subscribe(child);
+    });
 
     // questionable
     this.gameState.startGame();
 
-    this.appendChildren([translationHint, gameField, words, controls]);
+    this.appendChildren(children);
   }
 }

--- a/src/shared/Component.ts
+++ b/src/shared/Component.ts
@@ -95,8 +95,10 @@ export default class Component<T extends HTMLElement = HTMLElement> {
     return this.children;
   }
 
-  addClass(className: string) {
-    this.element.classList.add(className);
+  addClass(classNames: string) {
+    classNames.split(" ").forEach((className) => {
+      this.element.classList.add(className);
+    });
   }
 
   removeClass(className: string) {

--- a/src/ui/button/ButtonIcon.module.css
+++ b/src/ui/button/ButtonIcon.module.css
@@ -6,3 +6,9 @@
   display: grid;
   place-content: center;
 }
+
+.button:disabled {
+  border-color: var(--color-brand-800);
+  color: var(--color-brand-800);
+  background-color: transparent;
+}

--- a/src/ui/button/ButtonIcon.module.css
+++ b/src/ui/button/ButtonIcon.module.css
@@ -1,0 +1,8 @@
+.button {
+  width: 35px;
+  height: 35px;
+  border-radius: 100px;
+
+  display: grid;
+  place-content: center;
+}

--- a/src/ui/button/ButtonIcon.ts
+++ b/src/ui/button/ButtonIcon.ts
@@ -1,0 +1,28 @@
+import type Component from "../../shared/Component";
+
+import Button from "./Button";
+import { i } from "../tags";
+
+import styles from "./ButtonIcon.module.css";
+
+export default class ButtonIcon extends Button {
+  private icon: Component;
+
+  constructor(
+    private iconName: string,
+    onClick: EventListener,
+  ) {
+    super("", onClick, styles.button);
+
+    this.icon = i({ className: this.iconName });
+    this.append(this.icon);
+  }
+
+  updateIcon(newIconName: string) {
+    this.icon.getElement().className = "";
+
+    // this.icon.getElement().className = newIconName;
+
+    this.icon.addClass(newIconName);
+  }
+}

--- a/src/ui/tags.ts
+++ b/src/ui/tags.ts
@@ -55,3 +55,6 @@ export const h2 = (props: ElementFuncProps<HTMLHeadingElement>) =>
 
 export const h3 = (props: ElementFuncProps<HTMLHeadingElement>) =>
   new Component<HTMLHeadingElement>({ ...props, tag: "h3" });
+
+export const i = (props: ElementFuncProps) =>
+  new Component({ ...props, tag: "i" });


### PR DESCRIPTION
## What was done
Enhanced the game's user experience by adding a feature that allows players to choose the visibility of the translation hint using a toggle or button.

## Reason for the change
This control enables players to decide if the translation hint appears immediately with the sentence in the source data block or only after the sentence is correctly assembled.
