### PR TITLE
feat: PZ-21 Toggle pronunciation hint

### DIFF
--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -1,18 +1,17 @@
 import Component from "../../../shared/Component";
-import { Observer } from "../../../shared/Observer";
 import ButtonIcon from "../../../ui/button/ButtonIcon";
 import GameState from "../model/GameState";
+import { Observer } from "../../../shared/Observer";
 
 import styles from "./HintControls.module.css";
 
 // TODO: maybe use styled checkboxes instead of buttons
+// TODO: create settings type
+
 export default class HintsControls extends Component implements Observer {
   private translationButton: ButtonIcon;
 
-  // TODO: create settings type
-  // private currentSettings = {
-  //   translation: true,
-  // };
+  private pronunciationButton: ButtonIcon;
 
   constructor() {
     super({
@@ -21,10 +20,18 @@ export default class HintsControls extends Component implements Observer {
     });
 
     this.translationButton = new ButtonIcon("bi bi-lightbulb", () => {});
-    this.append(this.translationButton);
+    this.pronunciationButton = new ButtonIcon("bi bi-volume-up", () => {});
+
+    this.appendChildren([this.pronunciationButton, this.translationButton]);
   }
 
   update(gameState: GameState): void {
+    this.updateTranslationButton(gameState);
+    this.updatePronunciationButton(gameState);
+  }
+
+  // TODO: apply DRY
+  private updateTranslationButton(gameState: GameState) {
     let isTranslationShown = gameState.state.hints.settings.translation;
 
     if (gameState.isStageCompleted()) {
@@ -42,5 +49,23 @@ export default class HintsControls extends Component implements Observer {
       gameState.toggleTranslationHint.bind(gameState),
     );
     this.translationButton.updateIcon(iconName);
+  }
+
+  private updatePronunciationButton(gameState: GameState) {
+    let isAudioShown = gameState.state.hints.settings.audio;
+
+    if (gameState.isStageCompleted()) {
+      isAudioShown = true;
+      this.pronunciationButton.setAttribute("disabled", "");
+    } else {
+      this.pronunciationButton.removeAttribute("disabled");
+    }
+
+    const iconName = isAudioShown ? "bi bi-volume-mute" : "bi bi-volume-up";
+
+    this.pronunciationButton.updateCallback(
+      gameState.togglePronunciationHint.bind(gameState),
+    );
+    this.pronunciationButton.updateIcon(iconName);
   }
 }

--- a/src/features/game/hints/PronunciationHint.module.css
+++ b/src/features/game/hints/PronunciationHint.module.css
@@ -1,3 +1,10 @@
 .pronunciation {
   font-size: 1.5rem;
+  transition: all 0.3s;
+  pointer-events: all;
+}
+
+.hidden {
+  pointer-events: none;
+  opacity: 0;
 }

--- a/src/features/game/hints/PronunciationHint.ts
+++ b/src/features/game/hints/PronunciationHint.ts
@@ -43,9 +43,9 @@ export default class PronunciationHint extends Component implements Observer {
     const isShown = gameState.state.hints.settings.audio;
 
     if (isShown || gameState.isStageCompleted()) {
-      this.removeAttribute("hidden");
+      this.removeClass(styles.hidden);
     } else {
-      this.setAttribute("hidden", "");
+      this.addClass(styles.hidden);
     }
 
     const { audioPath } = gameState.state.hints.content;

--- a/src/features/game/hints/PronunciationHint.ts
+++ b/src/features/game/hints/PronunciationHint.ts
@@ -40,6 +40,14 @@ export default class PronunciationHint extends Component implements Observer {
   }
 
   update(gameState: GameState): void {
+    const isShown = gameState.state.hints.settings.audio;
+
+    if (isShown || gameState.isStageCompleted()) {
+      this.removeAttribute("hidden");
+    } else {
+      this.setAttribute("hidden", "");
+    }
+
     const { audioPath } = gameState.state.hints.content;
     const audioUrl = `${BASE_URL}/${audioPath}`;
 

--- a/src/features/game/hints/PronunciationHint.ts
+++ b/src/features/game/hints/PronunciationHint.ts
@@ -16,6 +16,7 @@ enum AudioStatus {
 const BASE_URL =
   "https://github.com/rolling-scopes-school/rss-puzzle-data/raw/main";
 
+// TODO: maybe create a generic hint class
 export default class PronunciationHint extends Component implements Observer {
   private audio: HTMLAudioElement | null = null;
 

--- a/src/features/game/model/GameState.ts
+++ b/src/features/game/model/GameState.ts
@@ -33,7 +33,7 @@ function prepareState(round: number, stage: number): GameData {
     },
     hints: {
       content: { translation, audioPath },
-      settings: { translation: false, audio: true },
+      settings: { translation: false, audio: false },
     },
   };
 }
@@ -85,6 +85,7 @@ export default class GameState extends State<GameData> {
     // zero-based
     if (this.state.levels.stage === STAGES_PER_ROUND - 1) return;
 
+    // FIX: resets settings
     this.state = prepareState(0, this.state.levels.stage + 1);
 
     this.notifySubscribers();
@@ -126,6 +127,12 @@ export default class GameState extends State<GameData> {
   toggleTranslationHint() {
     this.state.hints.settings.translation =
       !this.state.hints.settings.translation;
+
+    this.notifySubscribers();
+  }
+
+  togglePronunciationHint() {
+    this.state.hints.settings.audio = !this.state.hints.settings.audio;
 
     this.notifySubscribers();
   }

--- a/src/pages/game/GamePage.module.css
+++ b/src/pages/game/GamePage.module.css
@@ -15,6 +15,7 @@
   justify-items: center;
   align-items: center;
 
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 35px 1fr;
+  grid-template-rows: 35px;
   gap: 20px;
 }

--- a/src/ui/button/ButtonIcon.module.css
+++ b/src/ui/button/ButtonIcon.module.css
@@ -5,6 +5,7 @@
 
   display: grid;
   place-content: center;
+  font-size: 1.15rem;
 }
 
 .button:disabled {


### PR DESCRIPTION
## What was done
Implemented a toggle feature for the pronunciation hint in the game, allowing players to choose whether the audio icon or button for pronunciation is visible during gameplay.

## Reason for the change
These changes adds an element of challenge and choice to the gameplay.