### PR TITLE
refactor: PZ-37 Extract hint settings state

### DIFF
--- a/src/features/game/controls/GameControls.ts
+++ b/src/features/game/controls/GameControls.ts
@@ -1,7 +1,7 @@
 import Component from "../../../shared/Component";
 import Button from "../../../ui/button/Button";
-import GameState from "../model/GameState";
 
+import GameState from "../model/GameState";
 import { Observer } from "../../../shared/Observer";
 
 import styles from "./GameControls.module.css";
@@ -11,11 +11,12 @@ export default class GameControls extends Component implements Observer {
 
   gameFlowButton: Button;
 
-  constructor() {
+  constructor(gameState: GameState) {
     super({
       tag: "div",
       className: styles.controls,
     });
+    gameState.subscribe(this);
 
     this.autocompleteButton = new Button("Autocomplete", () => {});
     this.gameFlowButton = new Button("Check", () => {});

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -1,7 +1,7 @@
 import Component from "../../../shared/Component";
 import Row from "./Row";
-import GameState from "../model/GameState";
 
+import GameState from "../model/GameState";
 import { RowType } from "../types";
 import { Observer } from "../../../shared/Observer";
 
@@ -15,11 +15,13 @@ export default class GameField extends Component implements Observer {
 
   private currentRow: Row | null = null;
 
-  constructor() {
+  constructor(gameState: GameState) {
     super({
       tag: "div",
       className: styles.field,
     });
+
+    gameState.subscribe(this);
   }
 
   update(gameState: GameState) {

--- a/src/features/game/fields/WordsContainer.ts
+++ b/src/features/game/fields/WordsContainer.ts
@@ -1,7 +1,7 @@
 import Component from "../../../shared/Component";
 import Row from "./Row";
-import GameState from "../model/GameState";
 
+import GameState from "../model/GameState";
 import { RowType } from "../types";
 import { Observer } from "../../../shared/Observer";
 
@@ -10,11 +10,13 @@ import styles from "./WordsContainer.module.css";
 export default class WordsContainer extends Component implements Observer {
   row: Row | null = null;
 
-  constructor() {
+  constructor(gameState: GameState) {
     super({
       tag: "div",
       className: styles.words,
     });
+
+    gameState.subscribe(this);
   }
 
   update(gameState: GameState) {

--- a/src/features/game/hints/HintControls.module.css
+++ b/src/features/game/hints/HintControls.module.css
@@ -3,3 +3,47 @@
   gap: 10px;
   justify-content: end;
 }
+
+.button {
+  border: none;
+  border-radius: var(--border-radius-sm);
+  box-shadow: var(--shadow-sm);
+  padding: 0.8rem 1rem;
+  font-weight: 500;
+  color: var(--color-brand-50);
+  border: 1px solid transparent;
+  background-color: var(--color-brand-600);
+  width: 100%;
+  transition: 0.3s;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--color-brand-700);
+  }
+}
+
+.button:disabled {
+  border: 1px solid var(--color-brand-900);
+  color: var(--color-brand-900);
+  background-color: var(--color-grey-100);
+}
+
+.button {
+  width: 35px;
+  height: 35px;
+  border-radius: 100px;
+
+  display: grid;
+  place-content: center;
+  font-size: 1.15rem;
+}
+
+.button:disabled {
+  border-color: var(--color-brand-800);
+  color: var(--color-brand-800);
+  background-color: transparent;
+}
+
+input {
+  display: none;
+}

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -7,6 +7,7 @@ import { i, input, label } from "../../../ui/tags";
 
 import styles from "./HintControls.module.css";
 
+// Record maps each key to an object
 const iconClasses: Record<keyof HintSettingsData, { on: string; off: string }> =
   {
     translation: {
@@ -18,11 +19,6 @@ const iconClasses: Record<keyof HintSettingsData, { on: string; off: string }> =
       off: "bi bi-volume-mute",
     },
   };
-
-// type guard
-function isKeyOfHintSettingsData(key: string): key is keyof HintSettingsData {
-  return key in ({} as HintSettingsData);
-}
 
 export default class HintsControls extends Component implements Observer {
   constructor(private hintSettings: HintSettings) {
@@ -36,26 +32,28 @@ export default class HintsControls extends Component implements Observer {
     this.appendChildren([
       label(
         { className: styles.button },
-        i({ className: iconClasses.translation.on }),
-        input({ type: "checkbox", name: "translation" }),
+        i({ className: iconClasses.audio.on }),
+        input({ type: "checkbox", id: "audio" }),
       ),
       label(
         { className: styles.button },
-        i({ className: iconClasses.audio.on }),
-        input({ type: "checkbox", name: "audio" }),
+        i({ className: iconClasses.translation.on }),
+        input({ type: "checkbox", id: "translation" }),
       ),
     ]);
 
     this.addListener("change", this.handleChangeSetting.bind(this));
   }
 
+  // NOTE: this is a type guard defined as a class method (this way I can get access to the state object for checking). I don't really know whether it is a good idea or a bad one.
+  private isValidSetting(key: string): key is keyof HintSettingsData {
+    return key in this.hintSettings.state;
+  }
+
   private handleChangeSetting(e: Event) {
     const { target } = e;
-    if (
-      target instanceof HTMLInputElement &&
-      isKeyOfHintSettingsData(target.name)
-    ) {
-      this.hintSettings.toggleSetting(target.name);
+    if (target instanceof HTMLInputElement && this.isValidSetting(target.id)) {
+      this.hintSettings.toggleSetting(target.id);
     }
   }
 
@@ -67,16 +65,16 @@ export default class HintsControls extends Component implements Observer {
 
         if (
           checkboxEl instanceof HTMLInputElement &&
-          isKeyOfHintSettingsData(checkboxEl.name)
+          this.isValidSetting(checkboxEl.id)
         ) {
           // update value
-          checkboxEl.checked = publisher.state[checkboxEl.name];
+          checkboxEl.checked = publisher.state[checkboxEl.id];
 
           // update icon
           icon.resetClasses(
             checkboxEl.checked
-              ? iconClasses[checkboxEl.name].on
-              : iconClasses[checkboxEl.name].off,
+              ? iconClasses[checkboxEl.id].on
+              : iconClasses[checkboxEl.id].off,
           );
         }
       });

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -1,7 +1,9 @@
 import Component from "../../../shared/Component";
 import ButtonIcon from "../../../ui/button/ButtonIcon";
+
 import GameState from "../model/GameState";
-import { Observer } from "../../../shared/Observer";
+import HintSettings from "../model/HintSettings";
+import { Observer, Publisher } from "../../../shared/Observer";
 
 import styles from "./HintControls.module.css";
 
@@ -13,11 +15,14 @@ export default class HintsControls extends Component implements Observer {
 
   private pronunciationButton: ButtonIcon;
 
-  constructor() {
+  constructor(gameState: GameState, hintSettings: HintSettings) {
     super({
       tag: "div",
       className: styles.controls,
     });
+
+    gameState.subscribe(this);
+    hintSettings.subscribe(this);
 
     this.translationButton = new ButtonIcon("bi bi-lightbulb", () => {});
     this.pronunciationButton = new ButtonIcon("bi bi-volume-up", () => {});
@@ -25,9 +30,11 @@ export default class HintsControls extends Component implements Observer {
     this.appendChildren([this.pronunciationButton, this.translationButton]);
   }
 
-  update(gameState: GameState): void {
-    this.updateTranslationButton(gameState);
-    this.updatePronunciationButton(gameState);
+  update(state: Publisher): void {
+    if (state instanceof GameState) {
+      this.updateTranslationButton(state);
+      this.updatePronunciationButton(state);
+    }
   }
 
   // TODO: apply DRY

--- a/src/features/game/hints/PronunciationHint.ts
+++ b/src/features/game/hints/PronunciationHint.ts
@@ -3,6 +3,7 @@ import WaveIcon from "./WaveIcon";
 import ButtonIcon from "../../../ui/button/ButtonIcon";
 
 import GameState from "../model/GameState";
+import HintSettings from "../model/HintSettings";
 import { Observer } from "../../../shared/Observer";
 
 import styles from "./PronunciationHint.module.css";
@@ -26,11 +27,14 @@ export default class PronunciationHint extends Component implements Observer {
 
   private icon: WaveIcon;
 
-  constructor() {
+  constructor(gameState: GameState, hintSettings: HintSettings) {
     super({
       tag: "div",
       className: styles.pronunciation,
     });
+
+    gameState.subscribe(this);
+    hintSettings.subscribe(this);
 
     this.icon = new WaveIcon();
 

--- a/src/features/game/hints/PronunciationHint.ts
+++ b/src/features/game/hints/PronunciationHint.ts
@@ -1,10 +1,10 @@
 import Component from "../../../shared/Component";
 import WaveIcon from "./WaveIcon";
 import ButtonIcon from "../../../ui/button/ButtonIcon";
-
 import GameState from "../model/GameState";
+
 import HintSettings from "../model/HintSettings";
-import { Observer } from "../../../shared/Observer";
+import { Observer, Publisher } from "../../../shared/Observer";
 
 import styles from "./PronunciationHint.module.css";
 
@@ -27,6 +27,8 @@ export default class PronunciationHint extends Component implements Observer {
 
   private icon: WaveIcon;
 
+  private isShown: boolean | null = null;
+
   constructor(gameState: GameState, hintSettings: HintSettings) {
     super({
       tag: "div",
@@ -44,19 +46,25 @@ export default class PronunciationHint extends Component implements Observer {
     this.append(this.playButton);
   }
 
-  update(gameState: GameState): void {
-    const isShown = gameState.state.hints.settings.audio;
+  update(publisher: Publisher): void {
+    let isStageCompleted;
 
-    if (isShown || gameState.isStageCompleted()) {
-      this.removeClass(styles.hidden);
-    } else {
-      this.addClass(styles.hidden);
+    if (publisher instanceof GameState) {
+      isStageCompleted = publisher.isStageCompleted();
+
+      const { audioPath } = publisher.state.hints.content;
+      const audioUrl = `${BASE_URL}/${audioPath}`;
+
+      this.createAudio(audioUrl);
     }
 
-    const { audioPath } = gameState.state.hints.content;
-    const audioUrl = `${BASE_URL}/${audioPath}`;
+    if (publisher instanceof HintSettings) {
+      this.isShown = publisher.state.audio;
+    }
 
-    this.createAudio(audioUrl);
+    if (!this.isShown) this.addClass(styles.hidden);
+
+    if (isStageCompleted || this.isShown) this.removeClass(styles.hidden);
   }
 
   private createAudio(audioUrl: string) {

--- a/src/features/game/hints/TranslationHint.ts
+++ b/src/features/game/hints/TranslationHint.ts
@@ -1,15 +1,20 @@
 import Component from "../../../shared/Component";
-import { Observer } from "../../../shared/Observer";
+
 import GameState from "../model/GameState";
+import HintSettings from "../model/HintSettings";
+import { Observer } from "../../../shared/Observer";
 
 import styles from "./TranslationHint.module.css";
 
 export default class TranslationHint extends Component implements Observer {
-  constructor() {
+  constructor(gameState: GameState, hintSettings: HintSettings) {
     super({
       tag: "p",
       className: styles.translation,
     });
+
+    gameState.subscribe(this);
+    hintSettings.subscribe(this);
   }
 
   update(gameState: GameState): void {

--- a/src/features/game/model/GameState.ts
+++ b/src/features/game/model/GameState.ts
@@ -33,7 +33,6 @@ function prepareState(round: number, stage: number): GameData {
     },
     hints: {
       content: { translation, audioPath },
-      settings: { translation: false, audio: false },
     },
   };
 }
@@ -85,7 +84,6 @@ export default class GameState extends State<GameData> {
     // zero-based
     if (this.state.levels.stage === STAGES_PER_ROUND - 1) return;
 
-    // FIX: resets settings
     this.state = prepareState(0, this.state.levels.stage + 1);
 
     this.notifySubscribers();
@@ -122,18 +120,5 @@ export default class GameState extends State<GameData> {
     return [StageStatus.AUTOCOMPLETED, StageStatus.CORRECT].includes(
       this.state.levels.status,
     );
-  }
-
-  toggleTranslationHint() {
-    this.state.hints.settings.translation =
-      !this.state.hints.settings.translation;
-
-    this.notifySubscribers();
-  }
-
-  togglePronunciationHint() {
-    this.state.hints.settings.audio = !this.state.hints.settings.audio;
-
-    this.notifySubscribers();
   }
 }

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -2,8 +2,8 @@ import State from "../../../app/state/StatePublisher";
 import { HintSettingsData } from "../types";
 
 const initialState: HintSettingsData = {
-  translation: false,
-  audio: false,
+  translation: true,
+  audio: true,
 };
 
 export default class HintSettings extends State<HintSettingsData> {
@@ -11,8 +11,8 @@ export default class HintSettings extends State<HintSettingsData> {
     super(initialState);
   }
 
-  setSetting(setting: keyof HintSettingsData, value: boolean) {
-    this.state[setting] = value;
+  toggleSetting(setting: keyof HintSettingsData) {
+    this.state[setting] = !this.state[setting];
     this.notifySubscribers();
   }
 }

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -1,0 +1,18 @@
+import State from "../../../app/state/StatePublisher";
+import { HintSettingsData } from "../types";
+
+const initialState: HintSettingsData = {
+  translation: false,
+  audio: false,
+};
+
+export default class HintSettings extends State<HintSettingsData> {
+  constructor() {
+    super(initialState);
+  }
+
+  setSetting(setting: keyof HintSettingsData, value: boolean) {
+    this.state[setting] = value;
+    this.notifySubscribers();
+  }
+}

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -2,8 +2,8 @@ import State from "../../../app/state/StatePublisher";
 import { HintSettingsData } from "../types";
 
 const initialState: HintSettingsData = {
-  translation: true,
-  audio: true,
+  translation: false,
+  audio: false,
 };
 
 export default class HintSettings extends State<HintSettingsData> {

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -48,3 +48,8 @@ export interface GameData {
     };
   };
 }
+
+export interface HintSettingsData {
+  translation: boolean;
+  audio: boolean;
+}

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -42,10 +42,6 @@ export interface GameData {
       translation: string;
       audioPath: string;
     };
-    settings: {
-      translation: boolean;
-      audio: boolean;
-    };
   };
 }
 

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -6,7 +6,7 @@ import GameState from "../../features/game/model/GameState";
 import styles from "./GamePage.module.css";
 import GameControls from "../../features/game/controls/GameControls";
 import TranslationHint from "../../features/game/hints/TranslationHint";
-// import PronunciationHint from "../../features/game/hints/PronunciationHint";
+import PronunciationHint from "../../features/game/hints/PronunciationHint";
 import HintsControls from "../../features/game/hints/HintControls";
 import { div } from "../../ui/tags";
 import HintSettings from "../../features/game/model/HintSettings";
@@ -32,25 +32,26 @@ export default class GamePage extends Component {
     const gameField = new GameField(this.gameState);
     const words = new WordsContainer(this.gameState);
     const stageControls = new GameControls(this.gameState);
-    const hintControls = new HintsControls(this.gameState, this.hintSettings);
+    const hintControls = new HintsControls(this.hintSettings);
     const translationHint = new TranslationHint(
       this.gameState,
       this.hintSettings,
     );
-    // const pronunciationHint = new PronunciationHint(
-    //   this.gameState,
-    //   this.hintSettings,
-    // );
+    const pronunciationHint = new PronunciationHint(
+      this.gameState,
+      this.hintSettings,
+    );
 
     const hints = div(
       { className: styles.hints },
-      // pronunciationHint,
+      pronunciationHint,
       translationHint,
     );
 
     this.appendChildren([hintControls, hints, gameField, words, stageControls]);
 
     // questionable
-    this.gameState.startGame();
+    this.gameState.notifySubscribers();
+    this.hintSettings.notifySubscribers();
   }
 }

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -6,12 +6,15 @@ import GameState from "../../features/game/model/GameState";
 import styles from "./GamePage.module.css";
 import GameControls from "../../features/game/controls/GameControls";
 import TranslationHint from "../../features/game/hints/TranslationHint";
-import PronunciationHint from "../../features/game/hints/PronunciationHint";
+// import PronunciationHint from "../../features/game/hints/PronunciationHint";
 import HintsControls from "../../features/game/hints/HintControls";
 import { div } from "../../ui/tags";
+import HintSettings from "../../features/game/model/HintSettings";
 
 export default class GamePage extends Component {
   gameState: GameState;
+
+  hintSettings: HintSettings;
 
   constructor() {
     super({
@@ -20,36 +23,30 @@ export default class GamePage extends Component {
     });
 
     this.gameState = new GameState();
+    this.hintSettings = new HintSettings();
 
     this.configure();
   }
 
   private configure() {
-    const gameField = new GameField();
-    const words = new WordsContainer();
-    const stageControls = new GameControls();
-    const hintControls = new HintsControls();
-    const translationHint = new TranslationHint();
-    const pronunciationHint = new PronunciationHint();
+    const gameField = new GameField(this.gameState);
+    const words = new WordsContainer(this.gameState);
+    const stageControls = new GameControls(this.gameState);
+    const hintControls = new HintsControls(this.gameState, this.hintSettings);
+    const translationHint = new TranslationHint(
+      this.gameState,
+      this.hintSettings,
+    );
+    // const pronunciationHint = new PronunciationHint(
+    //   this.gameState,
+    //   this.hintSettings,
+    // );
 
     const hints = div(
       { className: styles.hints },
-      pronunciationHint,
+      // pronunciationHint,
       translationHint,
     );
-
-    const observers = [
-      hintControls,
-      translationHint,
-      pronunciationHint,
-      gameField,
-      words,
-      stageControls,
-    ];
-
-    observers.forEach((observer) => {
-      this.gameState.subscribe(observer);
-    });
 
     this.appendChildren([hintControls, hints, gameField, words, stageControls]);
 

--- a/src/shared/Component.ts
+++ b/src/shared/Component.ts
@@ -104,4 +104,12 @@ export default class Component<T extends HTMLElement = HTMLElement> {
   removeClass(className: string) {
     this.element.classList.remove(className);
   }
+
+  resetClasses(newClassName?: string) {
+    this.element.className = "";
+
+    if (newClassName) {
+      this.addClass(newClassName);
+    }
+  }
 }


### PR DESCRIPTION
## What was done
I extracted the hint state from the game state class and created a separate publisher to update the hint contents and visibility. Additionally, I refactored the hint components to subscribe to multiple states. Finally, I replaced the hint buttons with checkboxes.

## Reason for the change
The game state object contained a significant amount of loosely related data, including the hint settings state. This made the game state object a "god-object," which was problematic for maintainability and scalability.