### PR TITLE
fix: Show text inputs, hide checkboxes

### DIFF
--- a/src/features/game/hints/HintControls.module.css
+++ b/src/features/game/hints/HintControls.module.css
@@ -43,7 +43,3 @@
   color: var(--color-brand-800);
   background-color: transparent;
 }
-
-input {
-  display: none;
-}

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -33,12 +33,12 @@ export default class HintsControls extends Component implements Observer {
       label(
         { className: styles.button },
         i({ className: iconClasses.audio.on }),
-        input({ type: "checkbox", id: "audio" }),
+        input({ type: "checkbox", id: "audio", hidden: true }),
       ),
       label(
         { className: styles.button },
         i({ className: iconClasses.translation.on }),
-        input({ type: "checkbox", id: "translation" }),
+        input({ type: "checkbox", id: "translation", hidden: true }),
       ),
     ]);
 


### PR DESCRIPTION
## What was done
The visibility of the inputs has been fixed.

## Reason for the change
It was impossible to log into the app with the inputs hidden.

## Implementation details
I removed the global CSS class and then set the `hidden` attribute to true for the checkboxes.