### PR TITLE
feat: PZ-22 implement card background

### DIFF
--- a/src/features/game/card/WordCard.module.css
+++ b/src/features/game/card/WordCard.module.css
@@ -40,6 +40,9 @@
   .text {
     margin-left: 5px;
   }
+
+  background-size: 768px;
+  background-repeat: no-repeat;
 }
 
 .convex {
@@ -58,6 +61,9 @@
   border-radius: 0 100px 100px 0;
 
   background-color: var(--color-brand-700);
+
+  background-size: 768px;
+  background-repeat: no-repeat;
 }
 
 .word.first .content {

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -1,13 +1,19 @@
 import Component from "../../../shared/Component";
 
 import { Word, WordAction, RowType } from "../types";
+
+import { div, span } from "../../../ui/tags";
 import { assertNonNull } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";
 import rowStyles from "../fields/Row.module.css";
-import { div, span } from "../../../ui/tags";
 
 const DRAG_THRESHOLD = 2;
+
+const IMAGES_BASE_URL =
+  "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";
+const CARD_HEIGHT = 40;
+const CONVEX_HEIGHT = 20;
 
 export default class WordCard extends Component {
   private clientX: number = 0;
@@ -51,6 +57,29 @@ export default class WordCard extends Component {
     const convex = div({ className: styles.convex });
 
     this.appendChildren([content, convex]);
+    this.setBackground();
+    this.calculateBackgroundPositions();
+  }
+
+  setBackground() {
+    this.getChildren().forEach((child) => {
+      const element = child.getElement();
+      element.style.backgroundImage = `url(${IMAGES_BASE_URL}/${this.data.backgroundImage})`;
+    });
+  }
+
+  private calculateBackgroundPositions() {
+    const [content, convex] = this.getChildren();
+
+    const rowOffsetY = this.data.stage * CARD_HEIGHT;
+    const contentOffsetX = this.data.offset;
+    content.getElement().style.backgroundPosition = `-${contentOffsetX}px -${rowOffsetY}px`;
+
+    // the convex starts at the same place as the next piece
+    const convexOffsetX = this.data.offset + this.data.width;
+    // align the convex in the middle, the same as  `top: 50%; transformY: -50%`
+    const convexOffsetY = rowOffsetY + CARD_HEIGHT / 2 - CONVEX_HEIGHT / 2;
+    convex.getElement().style.backgroundPosition = `-${convexOffsetX}px -${convexOffsetY}px`;
   }
 
   private mouseDownHandler(e: MouseEvent): void {

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -5,8 +5,6 @@ import GameState from "../model/GameState";
 import { RowType } from "../types";
 import { Observer } from "../../../shared/Observer";
 
-import { splitSentence } from "../../../shared/helpers";
-
 import styles from "./GameField.module.css";
 import rowStyles from "./Row.module.css";
 
@@ -40,7 +38,7 @@ export default class GameField extends Component implements Observer {
       (sentence) =>
         new Row(
           RowType.ASSEMBLE,
-          new Array<null>(splitSentence(sentence).length).fill(null),
+          new Array<null>(sentence.split(" ").length).fill(null),
           gameState.actionHandler.bind(gameState),
         ),
     );

--- a/src/features/game/fields/Row.module.css
+++ b/src/features/game/fields/Row.module.css
@@ -35,9 +35,6 @@
   div {
     transition: all 0.3s;
     border: none;
-    background: var(--color-grey-50);
-    text-shadow: none;
-    color: var(--color-grey-800);
   }
 
   &::before {

--- a/src/features/game/model/GameState.ts
+++ b/src/features/game/model/GameState.ts
@@ -15,8 +15,13 @@ function prepareState(round: number, stage: number): GameData {
   const { sentence, translation, audioPath } = roundContent[stage];
   const allSentences = roundContent.map((entry) => entry.sentence);
   const sentenceLength = sentence.length;
+  const backgroundImage = rawData.rounds[round].levelData.imageSrc;
 
-  const shuffledSentence = getShuffledSentence(sentence);
+  const shuffledSentence = getShuffledSentence(
+    sentence,
+    stage,
+    backgroundImage,
+  );
 
   return {
     levels: {
@@ -32,7 +37,7 @@ function prepareState(round: number, stage: number): GameData {
       pickArea: shuffledSentence,
     },
     hints: {
-      content: { translation, audioPath },
+      content: { translation, audioPath, backgroundImage },
     },
   };
 }
@@ -103,8 +108,15 @@ export default class GameState extends State<GameData> {
 
   autocompleteRow() {
     const { pickArea, sentence } = this.state.content;
+    const { stage } = this.state.levels;
+    const { backgroundImage } = this.state.hints.content;
 
-    this.state.content.assembleArea = splitSentence(sentence);
+    // TODO: pass an object
+    this.state.content.assembleArea = splitSentence(
+      sentence,
+      stage,
+      backgroundImage,
+    );
     pickArea.fill(null);
 
     this.state.levels.status = StageStatus.AUTOCOMPLETED;

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -3,6 +3,9 @@ export interface Word {
   width: number;
   readonly correctPosition: number;
   isLast: boolean;
+  offset: number;
+  stage: number;
+  backgroundImage: string;
 }
 
 export interface WordAction {
@@ -41,6 +44,7 @@ export interface GameData {
     content: {
       translation: string;
       audioPath: string;
+      backgroundImage: string;
     };
   };
 }

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -13,17 +13,36 @@ export function calculateCardWidthPixels(sentence: string, word: string) {
   return (availableSpace * word.length) / totalCharacters + CONCAVE_WIDTH;
 }
 
-export function splitSentence(sentence: string): Array<Word> {
-  return sentence.split(" ").map((word, index, arr) => ({
-    text: word,
-    width: calculateCardWidthPixels(sentence, word),
-    correctPosition: index,
-    isLast: index === arr.length - 1,
-  }));
+export function splitSentence(
+  sentence: string,
+  stage: number,
+  backgroundImage: string,
+): Array<Word> {
+  let offset = 0;
+  return sentence.split(" ").map((word, index, arr) => {
+    const width = calculateCardWidthPixels(sentence, word);
+    const wordObj = {
+      text: word,
+      width: calculateCardWidthPixels(sentence, word),
+      correctPosition: index,
+      isLast: index === arr.length - 1,
+      offset,
+      stage,
+      backgroundImage,
+    };
+    offset += width;
+    return wordObj;
+  });
 }
 
-export function getShuffledSentence(sentence: string): Array<Word> {
-  return splitSentence(sentence).sort(() => Math.random() - 0.5);
+export function getShuffledSentence(
+  sentence: string,
+  stage: number,
+  backgroundImage: string,
+): Array<Word> {
+  return splitSentence(sentence, stage, backgroundImage).sort(
+    () => Math.random() - 0.5,
+  );
 }
 
 export function assertNonNull<T>(value: T | null | undefined): T {


### PR DESCRIPTION
## What Was Done

I implemented the background image feature for the cards, where each card displays a segment of a larger image.

## Reason for the Change

This puzzle-like aspect adds a visually engaging dimension to the sentence assembly task. Each sentence in the game corresponds to a different segment of the bigger picture, enhancing the players' experience by combining language learning with visual puzzle-solving.

## Implementation Details

The implementation heavily relies on the `background-image` and `background-position` CSS properties.