### PR TITLE
feat: PZ-23 Toggle background image hint

### DIFF
--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -15,6 +15,7 @@ const IMAGES_BASE_URL =
 const CARD_HEIGHT = 40;
 const CONVEX_HEIGHT = 20;
 
+// TODO: this class is too bloated. extract the Drag & Drop functionality into the Draggable class
 export default class WordCard extends Component {
   private clientX: number = 0;
 
@@ -30,6 +31,7 @@ export default class WordCard extends Component {
     private data: Word,
     private actionHandler: (action: WordAction) => void,
     private initRowType: RowType,
+    private isBackgroundDisplayed: boolean | null,
   ) {
     const lastWordClassName = data.isLast ? styles.last : "";
     const firstWordClassName = data.correctPosition === 0 ? styles.first : "";
@@ -57,14 +59,16 @@ export default class WordCard extends Component {
     const convex = div({ className: styles.convex });
 
     this.appendChildren([content, convex]);
-    this.setBackground();
     this.calculateBackgroundPositions();
+    this.setBackground(this.isBackgroundDisplayed);
   }
 
-  setBackground() {
+  setBackground(isHintEnabled: boolean | null) {
     this.getChildren().forEach((child) => {
       const element = child.getElement();
-      element.style.backgroundImage = `url(${IMAGES_BASE_URL}/${this.data.backgroundImage})`;
+      element.style.backgroundImage = isHintEnabled
+        ? `url(${IMAGES_BASE_URL}/${this.data.backgroundImage})`
+        : "none";
     });
   }
 

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -1,20 +1,29 @@
 import Component from "../../../shared/Component";
 import WordCard from "../card/WordCard";
-import { div } from "../../../ui/tags";
 
 import { Word, WordAction, RowType, StageStatus } from "../types";
+import { Observer, Publisher } from "../../../shared/Observer";
+import HintSettings from "../model/HintSettings";
+
+import { div } from "../../../ui/tags";
 
 import styles from "./Row.module.css";
 
-export default class Row extends Component {
+export default class Row extends Component implements Observer {
   private cells: Component[] = [];
+
+  // need this to prevent reset on cell updating
+  private isBackgroundDisplayed: boolean | null = null;
 
   constructor(
     private type: RowType,
     private content: Array<Word | null>,
     private actionHandler: (action: WordAction) => void,
+    private hintSettings: HintSettings,
   ) {
     super({ className: styles.row });
+
+    this.hintSettings.subscribe(this);
 
     this.configure();
   }
@@ -23,9 +32,20 @@ export default class Row extends Component {
     this.cells = this.content.map(() => div({ className: styles.cell }));
 
     this.appendChildren(this.cells);
+    // TODO: I have doubts about this, there is probably a better way
+    this.update(this.hintSettings);
   }
 
-  updateCells(content: Array<Word | null>) {
+  update(publisher: Publisher) {
+    if (publisher instanceof HintSettings) {
+      this.isBackgroundDisplayed = publisher.state.background;
+
+      this.toggleRowBackgrounds(this.isBackgroundDisplayed);
+    }
+  }
+
+  // TODO: this method needs a lot of refactoring
+  fillCells(content: Array<Word | null>) {
     this.cells.forEach((cell, index) => {
       const word = content[index];
       const cellEl = this.cells[index].getElement();
@@ -41,7 +61,12 @@ export default class Row extends Component {
         cellEl.style.maxWidth = `${word.width}px`;
         cellEl.style.minWidth = `${word.width}px`;
 
-        const card = new WordCard(word, this.actionHandler, this.type);
+        const card = new WordCard(
+          word,
+          this.actionHandler,
+          this.type,
+          this.isBackgroundDisplayed,
+        );
         card.setAttribute("data-index", index.toString());
 
         cell.append(card);
@@ -54,9 +79,30 @@ export default class Row extends Component {
     this.removeClass(styles.correct);
     this.removeClass(styles.incorrect);
 
-    if ([StageStatus.CORRECT, StageStatus.AUTOCOMPLETED].includes(status))
+    if ([StageStatus.CORRECT, StageStatus.AUTOCOMPLETED].includes(status)) {
       this.addClass(styles.correct);
 
+      this.toggleRowBackgrounds(true);
+
+      // solved rows always display background, so the row doesn't have to be affected by hint settings anymore
+      this.hintSettings.unsubscribe(this);
+    }
+
     if (status === StageStatus.INCORRECT) this.addClass(styles.incorrect);
+  }
+
+  private toggleRowBackgrounds(isShown: boolean) {
+    this.cells.forEach((cell) => {
+      const [card] = cell.getChildren();
+      if (card instanceof WordCard) {
+        card.setBackground(isShown);
+      }
+    });
+  }
+
+  deleteRow() {
+    // there should be no "dead" objects subscribed to the publisher
+    this.hintSettings.unsubscribe(this);
+    this.destroy();
   }
 }

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -18,6 +18,10 @@ const iconClasses: Record<keyof HintSettingsData, { on: string; off: string }> =
       on: "bi bi-volume-up",
       off: "bi bi-volume-mute",
     },
+    background: {
+      on: "bi bi-eye",
+      off: "bi bi-eye-slash",
+    },
   };
 
 export default class HintsControls extends Component implements Observer {
@@ -30,6 +34,11 @@ export default class HintsControls extends Component implements Observer {
     hintSettings.subscribe(this);
 
     this.appendChildren([
+      label(
+        { className: styles.button },
+        i({ className: iconClasses.background.on }),
+        input({ type: "checkbox", id: "background", hidden: true }),
+      ),
       label(
         { className: styles.button },
         i({ className: iconClasses.audio.on }),

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -4,6 +4,7 @@ import { HintSettingsData } from "../types";
 const initialState: HintSettingsData = {
   translation: false,
   audio: false,
+  background: false,
 };
 
 export default class HintSettings extends State<HintSettingsData> {

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -52,4 +52,5 @@ export interface GameData {
 export interface HintSettingsData {
   translation: boolean;
   audio: boolean;
+  background: boolean;
 }

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -29,8 +29,10 @@ export default class GamePage extends Component {
   }
 
   private configure() {
-    const gameField = new GameField(this.gameState);
-    const words = new WordsContainer(this.gameState);
+    // TODO: now I have to drill hint settings all the way down to the WordCard, find a better way
+    const gameField = new GameField(this.gameState, this.hintSettings);
+    const words = new WordsContainer(this.gameState, this.hintSettings);
+
     const stageControls = new GameControls(this.gameState);
     const hintControls = new HintsControls(this.hintSettings);
     const translationHint = new TranslationHint(


### PR DESCRIPTION
## What was done
I implemented a toggle feature that allows players to control the visibility of background images on puzzle pieces.

## Reason for the change
The option to hide images maintains an element of challenge for players and should only be used as a hint.

## Implementation details
I added another toggle button to the hint controls component and used the hint settings state to subscribe all rows to settings updates. When a player completes a stage, the corresponding row gets unsubscribed, as it shouldn't be affected by settings changes, meaning the background remains visible for the rest of the round.