### PR TITLE
feat: PZ-24 Implement a hint state persistence

### DIFF
--- a/src/app/state/StatePublisher.ts
+++ b/src/app/state/StatePublisher.ts
@@ -20,6 +20,12 @@ export default class State<T> implements Publisher {
     return this.defaultState;
   }
 
+  saveState() {
+    if (this.key) {
+      localStorage.setItem(this.key, JSON.stringify(this.state));
+    }
+  }
+
   subscribe(subscriber: Observer): void {
     this.subscribers.push(subscriber);
   }

--- a/src/app/state/StatePublisher.ts
+++ b/src/app/state/StatePublisher.ts
@@ -3,11 +3,22 @@ import { Publisher, Observer } from "../../shared/Observer";
 export default class State<T> implements Publisher {
   public state: T;
 
-  constructor(initialState: T) {
-    this.state = initialState;
+  constructor(
+    private defaultState: T,
+    private key: string = "",
+  ) {
+    this.state = this.loadState();
   }
 
   private subscribers: Array<Observer> = [];
+
+  private loadState() {
+    const stateString = localStorage.getItem(this.key);
+
+    if (stateString) return JSON.parse(stateString) as T;
+
+    return this.defaultState;
+  }
 
   subscribe(subscriber: Observer): void {
     this.subscribers.push(subscriber);

--- a/src/features/auth/AuthState.ts
+++ b/src/features/auth/AuthState.ts
@@ -17,6 +17,9 @@ export default class AuthState extends State<UserCredentials> {
   }
 
   logout() {
+    // NOTE: although it may seem somewhat unrelated to do it within this state, I believe it's a much simpler solution than trying to synchronize multiple states/components, so I decided to go with it
+    localStorage.removeItem("hintSettings");
+
     this.resetState();
     this.saveState();
   }

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -1,15 +1,15 @@
 import State from "../../../app/state/StatePublisher";
 import { HintSettingsData } from "../types";
 
-const initialState: HintSettingsData = {
-  translation: false,
-  audio: false,
-  background: false,
+const defaultState: HintSettingsData = {
+  translation: true,
+  audio: true,
+  background: true,
 };
 
 export default class HintSettings extends State<HintSettingsData> {
   constructor() {
-    super(initialState);
+    super(defaultState, "hintSettings");
   }
 
   toggleSetting(setting: keyof HintSettingsData) {

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -14,6 +14,7 @@ export default class HintSettings extends State<HintSettingsData> {
 
   toggleSetting(setting: keyof HintSettingsData) {
     this.state[setting] = !this.state[setting];
+    this.saveState();
     this.notifySubscribers();
   }
 }


### PR DESCRIPTION
## What was done
Implement a feature to save the state (enabled or disabled) of each hint in local storage.

## Reason for the change
This feature ensures a personalized and consistent gameplay experience and maintains a fresh start for each new game session.