### PR TITLE
fix: PZ-81 Create correct amount of cells

### DIFF
--- a/data/levels.ts
+++ b/data/levels.ts
@@ -1,0 +1,11 @@
+import level1 from "./wordCollectionLevel1.json";
+import level2 from "./wordCollectionLevel2.json";
+import level3 from "./wordCollectionLevel3.json";
+import level4 from "./wordCollectionLevel4.json";
+import level5 from "./wordCollectionLevel5.json";
+import level6 from "./wordCollectionLevel6.json";
+
+// TODO: fetch this data
+const LEVELS = [level1, level2, level3, level4, level5, level6];
+
+export default LEVELS;

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -12,7 +12,7 @@ import { calculateImageAspectRatio } from "../../../shared/helpers";
 export default class GameField extends Component implements Observer {
   private rows: Array<Row> = [];
 
-  private currentStage: number = -1;
+  private roundId: string = "";
 
   constructor(
     private roundState: RoundState,
@@ -28,14 +28,14 @@ export default class GameField extends Component implements Observer {
 
   async update(publisher: Publisher) {
     if (publisher instanceof RoundState) {
-      const { currentStage } = publisher.state;
+      const { currentStage, id } = publisher.state;
 
       // new round
-      if (currentStage === 0 && this.currentStage !== 0) {
+      if (id !== this.roundId) {
         this.createRows(publisher);
       }
 
-      this.currentStage = currentStage;
+      this.roundId = id;
       const currentRow = this.rows[currentStage];
 
       this.rows.forEach((row) => {

--- a/src/features/game/model/RoundSettings.ts
+++ b/src/features/game/model/RoundSettings.ts
@@ -1,15 +1,5 @@
 import State from "../../../app/state/StatePublisher";
-
-// TODO: fetch this data
-// TODO: fix repeating code issue
-import level1 from "../../../../data/wordCollectionLevel1.json";
-import level2 from "../../../../data/wordCollectionLevel2.json";
-import level3 from "../../../../data/wordCollectionLevel3.json";
-import level4 from "../../../../data/wordCollectionLevel4.json";
-import level5 from "../../../../data/wordCollectionLevel5.json";
-import level6 from "../../../../data/wordCollectionLevel6.json";
-
-const LEVELS = [level1, level2, level3, level4, level5, level6];
+import LEVELS from "../../../../data/levels";
 
 interface RoundSettingsData {
   difficultyLevel: number;

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -4,20 +4,12 @@ import { Observer, Publisher } from "../../../shared/Observer";
 
 import { MoveCardAction, Round, StageStatus } from "../types";
 import { generateStageWords } from "../../../shared/helpers";
-
-import level1 from "../../../../data/wordCollectionLevel1.json";
-import level2 from "../../../../data/wordCollectionLevel2.json";
-import level3 from "../../../../data/wordCollectionLevel3.json";
-import level4 from "../../../../data/wordCollectionLevel4.json";
-import level5 from "../../../../data/wordCollectionLevel5.json";
-import level6 from "../../../../data/wordCollectionLevel6.json";
-
-// TODO: fetch this data
-const LEVELS = [level1, level2, level3, level4, level5, level6];
+import LEVELS from "../../../../data/levels";
 
 function prepareRound(difficulty: number, round: number): Round {
   const rawData = LEVELS[difficulty].rounds[round].words;
-  const { author, name, imageSrc } = LEVELS[difficulty].rounds[round].levelData;
+  const { author, name, imageSrc, id } =
+    LEVELS[difficulty].rounds[round].levelData;
 
   const stages = rawData.map((entry, index) => ({
     stageNumber: index,
@@ -29,6 +21,7 @@ function prepareRound(difficulty: number, round: number): Round {
   }));
 
   return {
+    id,
     currentStage: 0,
     painting: { author, name, imageSrc },
     stages,

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -57,6 +57,7 @@ export interface Painting {
 }
 
 export interface Round {
+  id: string;
   currentStage: number;
   painting: Painting;
   stages: Array<Stage>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "eslint.config.js"]
+  "include": ["src", "eslint.config.js", "data"]
 }


### PR DESCRIPTION
## What was done
Created the correct number of cells for each row at the start of a round.

## Reason for the change
When a player completed the first stage and chose to select a different round before moving on to the second stage, the rows did not reinitialize properly.

## Implementation details
Introduced a round ID to track the start of a new round.