### PR TITLE
feat: PZ-28 Reveal image and information

### DIFF
--- a/data/wordCollectionLevel1.json
+++ b/data/wordCollectionLevel1.json
@@ -6,7 +6,7 @@
         "name": "Stag Hunt",
         "imageSrc": "level1/deerhunt.jpg",
         "cutSrc": "level1/cut/deerhunt.jpg",
-        "author": "Niccolò dell'",
+        "author": "Niccolò dell'Abbate",
         "year": "1550-52"
       },
       "words": [

--- a/src/features/game/card/PaintingInfo.module.css
+++ b/src/features/game/card/PaintingInfo.module.css
@@ -1,0 +1,52 @@
+.info {
+  display: grid;
+  place-content: center;
+
+  margin: 0 auto;
+  width: max-content;
+
+  background-color: var(--color-grey-50);
+  border-radius: var(--border-radius-sm);
+  box-shadow: var(--shadow-md);
+
+  text-align: center;
+
+  font-weight: 500;
+  line-height: 1.3;
+
+  opacity: 0;
+  height: 0;
+  overflow: hidden;
+  transform: scaleY(0);
+
+  transition: height 1s;
+}
+
+.appeared {
+  height: 90px;
+  padding: 1rem 1.2rem;
+  animation-name: appear;
+  animation-duration: 0.3s;
+  animation-delay: 2s;
+  animation-fill-mode: forwards;
+}
+
+.name {
+  font-weight: 900;
+  max-width: 35ch;
+}
+
+.year {
+  font-size: 0.8rem;
+}
+
+.author {
+}
+
+@keyframes appear {
+  100% {
+    opacity: 1;
+    overflow: visible;
+    transform: scaleY(1);
+  }
+}

--- a/src/features/game/card/PaintingInfo.ts
+++ b/src/features/game/card/PaintingInfo.ts
@@ -1,0 +1,46 @@
+import Component from "../../../shared/Component";
+import { Observer, Publisher } from "../../../shared/Observer";
+import { p } from "../../../ui/tags";
+import RoundState from "../model/RoundState";
+import { Painting } from "../types";
+
+import styles from "./PaintingInfo.module.css";
+
+export default class PaintingInfo extends Component implements Observer {
+  constructor(private roundState: RoundState) {
+    super(
+      {
+        tag: "div",
+        className: styles.info,
+      },
+      p({ className: styles.name }),
+      p({ className: styles.author }),
+      p({ className: styles.year }),
+    );
+
+    this.roundState.subscribe(this);
+  }
+
+  update(publisher: Publisher) {
+    if (publisher instanceof RoundState) {
+      const isRoundCompleted = publisher.isRoundCompleted();
+      this.updateContent(publisher.state.painting, isRoundCompleted);
+      this.toggleVisibility(isRoundCompleted);
+    }
+  }
+
+  private updateContent(painting: Painting, isRoundCompleted: boolean) {
+    const paragraphs = this.getChildren();
+    const { name, author, year } = painting;
+
+    [name, author, year].forEach((value, index) => {
+      paragraphs[index].setTextContent(isRoundCompleted ? value : "");
+    });
+  }
+
+  private toggleVisibility(isDisplayed: boolean) {
+    if (isDisplayed) {
+      this.addClass(styles.appeared);
+    } else this.removeClass(styles.appeared);
+  }
+}

--- a/src/features/game/card/WordCard.module.css
+++ b/src/features/game/card/WordCard.module.css
@@ -88,3 +88,9 @@
 .word.last .convex {
   display: none;
 }
+
+.faded {
+  opacity: 0;
+  transition-property: opacity;
+  transition-duration: 0.2s;
+}

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -25,6 +25,8 @@ export default class WordCard extends Component {
 
   private lastDropTarget: HTMLElement | null = null;
 
+  private textSpan: Component;
+
   constructor(
     private data: Word,
     private actionHandler: (action: MoveCardAction) => void,
@@ -44,14 +46,12 @@ export default class WordCard extends Component {
       this.mouseDownHandler.bind(this),
     );
 
+    this.textSpan = span({ className: styles.text, text: this.data.text });
     this.configure();
   }
 
   private configure() {
-    const content = div(
-      { className: styles.content },
-      span({ className: styles.text, text: this.data.text }),
-    );
+    const content = div({ className: styles.content }, this.textSpan);
     const convex = div({ className: styles.convex });
 
     this.appendChildren([content, convex]);
@@ -101,6 +101,11 @@ export default class WordCard extends Component {
 
     content.setInlineStyles(contentStyles);
     convex.setInlineStyles(convexStyles);
+  }
+
+  fadeAwayCardText(transitionDelay: number) {
+    this.textSpan.addClass(styles.faded);
+    this.textSpan.setInlineStyles({ transitionDelay: `${transitionDelay}s` });
   }
 
   private mouseDownHandler(e: MouseEvent): void {

--- a/src/features/game/fields/GameField.module.css
+++ b/src/features/game/fields/GameField.module.css
@@ -7,3 +7,10 @@
   aspect-ratio: 1.5;
   transition: all 0.3s;
 }
+
+.completed {
+  span {
+    opacity: 0;
+    transition: all 0.3s ease 0.5s;
+  }
+}

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -8,6 +8,7 @@ import HintSettings from "../model/HintSettings";
 import { RowType } from "../types";
 import { Observer, Publisher } from "../../../shared/Observer";
 import {
+  ANIMATION_DELAY_COEFFICIENT,
   calculateImageAspectRatio,
   findAllInstancesOf,
 } from "../../../shared/helpers";
@@ -68,8 +69,6 @@ export default class GameField extends Component implements Observer {
   }
 
   private fadeAwayAllCards(isRoundCompleted: boolean) {
-    const ANIMATION_DELAY_COEFFICIENT = 20;
-
     if (isRoundCompleted) {
       const cards = findAllInstancesOf(WordCard, this);
       cards.forEach((card, index) => {

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -14,6 +14,8 @@ export default class GameField extends Component implements Observer {
 
   private roundId: string = "";
 
+  private currentRow: Row = this.rows[0];
+
   constructor(
     private roundState: RoundState,
     private hintSettings: HintSettings,
@@ -36,20 +38,34 @@ export default class GameField extends Component implements Observer {
       }
 
       this.roundId = id;
-      const currentRow = this.rows[currentStage];
+      this.currentRow = this.rows[currentStage];
 
       this.rows.forEach((row) => {
         row.deactivateRow();
       });
-      currentRow.activateRow();
+      this.currentRow.activateRow();
 
-      currentRow.fillCells(publisher.state.content.assembleArea);
-      currentRow.updateStatusStyles(
-        publisher.state.stages[currentStage].status,
-      );
-      await this.updateFieldSize();
-      await currentRow.updateBackgroundPositions();
+      this.currentRow.fillCells(publisher.state.content.assembleArea);
+      await this.updateVisuals();
     }
+  }
+
+  private async updateVisuals() {
+    await this.updateFieldSize();
+    this.toogleFinishedRound(this.roundState.isRoundCompleted());
+
+    // TODO: subscribe rows to state updates
+    // TODO: create a current stage getter
+    this.currentRow.updateStatusStyles(
+      this.roundState.state.stages[this.roundState.state.currentStage].status,
+    );
+    await this.currentRow.updateBackgroundPositions();
+  }
+
+  private toogleFinishedRound(isRoundCompleted: boolean) {
+    if (isRoundCompleted) {
+      this.addClass(styles.completed);
+    } else this.removeClass(styles.completed);
   }
 
   private async updateFieldSize() {

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -1,13 +1,18 @@
 import Component from "../../../shared/Component";
 import Row from "./Row";
+import WordCard from "../card/WordCard";
 
-import { RowType } from "../types";
-import { Observer, Publisher } from "../../../shared/Observer";
 import RoundState from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
+import { RowType } from "../types";
+import { Observer, Publisher } from "../../../shared/Observer";
+import {
+  calculateImageAspectRatio,
+  findAllInstancesOf,
+} from "../../../shared/helpers";
+
 import styles from "./GameField.module.css";
-import { calculateImageAspectRatio } from "../../../shared/helpers";
 
 export default class GameField extends Component implements Observer {
   private rows: Array<Row> = [];
@@ -52,7 +57,7 @@ export default class GameField extends Component implements Observer {
 
   private async updateVisuals() {
     await this.updateFieldSize();
-    this.toogleFinishedRound(this.roundState.isRoundCompleted());
+    this.fadeAwayAllCards(this.roundState.isRoundCompleted());
 
     // TODO: subscribe rows to state updates
     // TODO: create a current stage getter
@@ -62,10 +67,15 @@ export default class GameField extends Component implements Observer {
     await this.currentRow.updateBackgroundPositions();
   }
 
-  private toogleFinishedRound(isRoundCompleted: boolean) {
+  private fadeAwayAllCards(isRoundCompleted: boolean) {
+    const ANIMATION_DELAY_COEFFICIENT = 20;
+
     if (isRoundCompleted) {
-      this.addClass(styles.completed);
-    } else this.removeClass(styles.completed);
+      const cards = findAllInstancesOf(WordCard, this);
+      cards.forEach((card, index) => {
+        card.fadeAwayCardText(index / ANIMATION_DELAY_COEFFICIENT);
+      });
+    }
   }
 
   private async updateFieldSize() {

--- a/src/features/game/fields/WordsPicker.module.css
+++ b/src/features/game/fields/WordsPicker.module.css
@@ -1,8 +1,29 @@
 .words {
+  position: relative;
   background-color: var(--color-grey-50);
   box-shadow: var(--shadow-sm);
 
   width: 100%;
   height: 40px;
   transition: height 0.3s;
+}
+
+.info {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  opacity: 0;
+  transition-property: opacity;
+  transition-duration: 0.3s;
+
+  font-weight: 500;
+}
+
+.appeared {
+  opacity: 1;
 }

--- a/src/features/game/fields/WordsPicker.module.css
+++ b/src/features/game/fields/WordsPicker.module.css
@@ -5,25 +5,5 @@
 
   width: 100%;
   height: 40px;
-  transition: height 0.3s;
-}
-
-.info {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  opacity: 0;
-  transition-property: opacity;
-  transition-duration: 0.3s;
-
-  font-weight: 500;
-}
-
-.appeared {
-  opacity: 1;
+  transition: all 0.3s;
 }

--- a/src/features/game/fields/WordsPicker.ts
+++ b/src/features/game/fields/WordsPicker.ts
@@ -1,6 +1,5 @@
 import Component from "../../../shared/Component";
 import Row from "./Row";
-import { p } from "../../../ui/tags";
 
 import RoundState from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
@@ -8,10 +7,7 @@ import HintSettings from "../model/HintSettings";
 import { RowType } from "../types";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import {
-  ANIMATION_DELAY_COEFFICIENT,
-  calculateImageAspectRatio,
-} from "../../../shared/helpers";
+import { calculateImageAspectRatio } from "../../../shared/helpers";
 
 import styles from "./WordsPicker.module.css";
 
@@ -19,8 +15,6 @@ export default class WordsPicker extends Component implements Observer {
   private row: Row | null = null;
 
   private imageAspectRatio: number = 0;
-
-  private paintingInfo: Component;
 
   constructor(
     private roundState: RoundState,
@@ -32,12 +26,6 @@ export default class WordsPicker extends Component implements Observer {
     });
 
     roundState.subscribe(this);
-
-    this.paintingInfo = p({
-      className: styles.info,
-      text: "sdfsgjsgh- sdgjhjsgj",
-    });
-    this.append(this.paintingInfo);
 
     window.addEventListener("resize", this.handleResize.bind(this));
   }
@@ -51,30 +39,18 @@ export default class WordsPicker extends Component implements Observer {
         this.row = this.createRow(publisher);
       }
 
+      this.toggleVisibility(publisher.isRoundCompleted());
+
       this.row.fillCells(publisher.state.content.pickArea);
       await this.updateHeight();
       await this.row.updateBackgroundPositions();
-      this.revealPaintingInfo(publisher);
     }
   }
 
-  private revealPaintingInfo(publisher: RoundState) {
-    const isRoundCompleted = publisher.isRoundCompleted();
-    const { author, name, year } = publisher.state.painting;
-    const infoString = `${author} — ${name} (${year})`;
-
-    const totalWords = publisher.state.stages.reduce(
-      (acc, cur) => acc + cur.sentenceLength,
-      0,
-    );
-
-    if (isRoundCompleted) {
-      this.paintingInfo.setTextContent(infoString);
-      this.paintingInfo.addClass(styles.appeared);
-      this.paintingInfo.setInlineStyles({
-        transitionDelay: `${(totalWords - 1) / ANIMATION_DELAY_COEFFICIENT}s`,
-      });
-    } else this.paintingInfo.removeClass(styles.appeared);
+  private toggleVisibility(isDisplayed: boolean) {
+    if (isDisplayed) {
+      this.setAttribute("hidden", "");
+    } else this.removeAttribute("hidden");
   }
 
   private handleResize() {
@@ -91,7 +67,6 @@ export default class WordsPicker extends Component implements Observer {
     }
 
     const { width } = this.getElement().getBoundingClientRect();
-
     this.getElement().style.height = `${width / this.imageAspectRatio / 10}px`;
   }
 

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,7 +2,7 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { MoveCardAction, Round, StageStatus } from "../types";
+import { MoveCardAction, Round, Stage, StageStatus } from "../types";
 import { generateStageWords } from "../../../shared/helpers";
 import LEVELS from "../../../../data/levels";
 
@@ -140,13 +140,19 @@ export default class RoundState extends State<Round> implements Observer {
     this.state.stages[this.state.currentStage].status = updatedStatus;
   }
 
-  isStageCompleted(): boolean {
+  isStageCompleted(
+    stage: Stage = this.state.stages[this.state.currentStage],
+  ): boolean {
     return [StageStatus.AUTOCOMPLETED, StageStatus.CORRECT].includes(
-      this.state.stages[this.state.currentStage].status,
+      stage.status,
     );
   }
 
   isAssembled() {
     return this.state.content.assembleArea.every((word) => word);
+  }
+
+  isRoundCompleted(): boolean {
+    return this.state.stages.every((stage) => this.isStageCompleted(stage));
   }
 }

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -8,7 +8,7 @@ import LEVELS from "../../../../data/levels";
 
 function prepareRound(difficulty: number, round: number): Round {
   const rawData = LEVELS[difficulty].rounds[round].words;
-  const { author, name, imageSrc, id } =
+  const { author, name, imageSrc, id, year } =
     LEVELS[difficulty].rounds[round].levelData;
 
   const stages = rawData.map((entry, index) => ({
@@ -23,7 +23,7 @@ function prepareRound(difficulty: number, round: number): Round {
   return {
     id,
     currentStage: 0,
-    painting: { author, name, imageSrc },
+    painting: { author, name, year, imageSrc },
     stages,
     content: {
       pickArea: [],

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -54,6 +54,7 @@ export interface Painting {
   author: string;
   name: string;
   imageSrc: string;
+  year: string;
 }
 
 export interface Round {

--- a/src/pages/game/GamePage.module.css
+++ b/src/pages/game/GamePage.module.css
@@ -11,9 +11,10 @@
   width: min(768px, 100%);
   padding: 20px;
 
+  transition: all 0.3s;
+
   @container (width < 500px) {
     place-content: start;
-    row-gap: 2rem;
     padding: 5px;
   }
 }

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -1,21 +1,25 @@
 import Component from "../../shared/Component";
+import SmallScreenWarningCard from "../../features/game/card/SmallScreenWarningCard";
+
 import GameField from "../../features/game/fields/GameField";
 import WordsPicker from "../../features/game/fields/WordsPicker";
+import PaintingInfo from "../../features/game/card/PaintingInfo";
 import RoundState from "../../features/game/model/RoundState";
 
-import styles from "./GamePage.module.css";
-import GameControls from "../../features/game/controls/GameControls";
 import TranslationHint from "../../features/game/hints/TranslationHint";
 import PronunciationHint from "../../features/game/hints/PronunciationHint";
-import HintsControls from "../../features/game/hints/HintControls";
-import HintSettings from "../../features/game/model/HintSettings";
-import RoundControls from "../../features/game/controls/RoundControls";
-import RoundSettings from "../../features/game/model/RoundSettings";
 
-import SmallScreenWarningCard from "../../features/game/card/SmallScreenWarningCard";
+import GameControls from "../../features/game/controls/GameControls";
+import HintsControls from "../../features/game/hints/HintControls";
+import RoundControls from "../../features/game/controls/RoundControls";
+
+import RoundSettings from "../../features/game/model/RoundSettings";
+import HintSettings from "../../features/game/model/HintSettings";
 import SmallScreenSettings from "../../features/game/model/SmallScreenSettings";
 
 import { div } from "../../ui/tags";
+
+import styles from "./GamePage.module.css";
 
 export default class GamePage extends Component {
   roundSettings: RoundSettings;
@@ -54,10 +58,11 @@ export default class GamePage extends Component {
 
   private configureFieds() {
     const gameField = new GameField(this.roundState, this.hintSettings);
+    const paintingInfo = new PaintingInfo(this.roundState);
     const wordsPicker = new WordsPicker(this.roundState, this.hintSettings);
     const roundControls = new GameControls(this.roundState);
 
-    return [gameField, wordsPicker, roundControls];
+    return [gameField, paintingInfo, wordsPicker, roundControls];
   }
 
   private configurHints() {

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,4 +1,5 @@
 import { Stage, Word } from "../features/game/types";
+import Component from "./Component";
 
 const IMAGES_BASE_URL =
   "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";
@@ -75,4 +76,22 @@ export async function calculateImageAspectRatio(src: string) {
   });
 
   return image.naturalWidth / image.naturalHeight;
+}
+
+// use never since any is not allowed
+export function findAllInstancesOf<T>(
+  classConstructor: new (...args: never[]) => T, // return an instance of type T
+  component: Component,
+): T[] {
+  let instances: T[] = [];
+
+  if (component instanceof classConstructor) {
+    instances.push(component);
+  }
+
+  component.getChildren().forEach((child) => {
+    instances = instances.concat(findAllInstancesOf(classConstructor, child));
+  });
+
+  return instances;
 }

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -5,6 +5,7 @@ const IMAGES_BASE_URL =
   "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";
 const ROW_WIDTH = 728;
 const CONCAVE_WIDTH = 10;
+export const ANIMATION_DELAY_COEFFICIENT = 50;
 
 // take concave width into account in order to visually align narrow pieces like "a", "I", "at" etc
 export function calculateCardWidthPixels(sentence: string, word: string) {


### PR DESCRIPTION
## What was done
Created a feature that, upon the correct assembly of all ten sentences in a round, gradually fades away the text on cards. 
Additionally, displayed brief information about the revealed image, such as the author, title, and year of creation.

## Reason for the change
This functionality adds both a visual reward and educational value to the game, enhancing player engagement and learning.
