### PR TITLE
feat: PZ-30 Add continue button to stats

### DIFF
--- a/src/features/game/stats/RoundStats.module.css
+++ b/src/features/game/stats/RoundStats.module.css
@@ -1,8 +1,12 @@
 .stats {
-  display: grid;
-  place-content: center;
   height: 100%;
+  display: grid;
+  justify-items: center;
 
   font-weight: 700;
-  font-size: 1.5rem;
+}
+
+.continue {
+  align-self: end;
+  width: max-content;
 }

--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -4,6 +4,7 @@ import RoundState from "../model/RoundState";
 import { Observer, Publisher } from "../../../shared/Observer";
 
 import styles from "./RoundStats.module.css";
+import Button from "../../../ui/button/Button";
 
 export default class RoundStats extends Component implements Observer {
   constructor(
@@ -13,11 +14,18 @@ export default class RoundStats extends Component implements Observer {
     super({ tag: "div", className: styles.stats });
 
     this.roundState.subscribe(this);
+
+    const continueButton = new Button(
+      "Continue",
+      this.roundState.startNextStage.bind(this.roundState),
+      styles.continue,
+    );
+
+    this.append(continueButton);
   }
 
   update(publisher: Publisher): void {
     if (publisher instanceof RoundState && publisher.isRoundCompleted()) {
-      this.setTextContent("Round stats");
       this.modal.updateContent(this);
     }
   }

--- a/src/ui/modal/Modal.module.css
+++ b/src/ui/modal/Modal.module.css
@@ -45,5 +45,4 @@ body:has(.modal[open]) {
 .content {
   height: 100%;
   width: 100%;
-  overflow-y: scroll;
 }


### PR DESCRIPTION
## What was done
Incorporated a button, labeled 'Continue' on the statistics page. 

## Reason for the change
This addition is crucial for providing a seamless transition and maintaining the flow of the game, enabling players to move effortlessly from reviewing their performance to engaging in the next round.

## Implementation details
This button, when clicked, should navigates the player to the next round of the game. 
