### PR TITLE
feat: PZ-33 Display artwork miniature on statistics window

### DIFF
--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -3,15 +3,12 @@ import Component from "../../../shared/Component";
 import { Word, MoveCardAction, RowType } from "../types";
 
 import { div, span } from "../../../ui/tags";
-import { assertNonNull } from "../../../shared/helpers";
+import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";
 import rowStyles from "../fields/Row.module.css";
 
 const DRAG_THRESHOLD = 2;
-
-const IMAGES_BASE_URL =
-  "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";
 
 // TODO: this class is too bloated. extract the Drag & Drop functionality into the Draggable class
 export default class WordCard extends Component {

--- a/src/features/game/stats/ArtworkMiniature.module.css
+++ b/src/features/game/stats/ArtworkMiniature.module.css
@@ -1,0 +1,29 @@
+.miniature {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+
+  @media (orientation: landscape) and (height < 400px) {
+    display: none;
+  }
+}
+
+.image {
+  object-fit: cover;
+  width: clamp(120px, 10vw, 50%);
+
+  border-radius: var(--border-radius-sm);
+}
+
+.info {
+  text-align: center;
+  line-height: 1.3;
+}
+
+.info p:first-child {
+  font-weight: 900;
+}
+
+.info p:last-child {
+  font-size: 0.8rem;
+}

--- a/src/features/game/stats/ArtworkMiniature.ts
+++ b/src/features/game/stats/ArtworkMiniature.ts
@@ -1,0 +1,38 @@
+import Component from "../../../shared/Component";
+import { div, img, p } from "../../../ui/tags";
+
+import { Painting } from "../types";
+import { IMAGES_BASE_URL } from "../../../shared/helpers";
+
+import styles from "./ArtworkMiniature.module.css";
+
+export default class ArtworkMiniature extends Component {
+  private image: Component<HTMLImageElement>;
+
+  private info: Component;
+
+  constructor(painting: Painting) {
+    super({
+      tag: "div",
+      className: styles.miniature,
+    });
+
+    this.image = img({ src: "", alt: "", className: styles.image });
+    this.info = div({ className: styles.info });
+    this.updateContent(painting);
+
+    this.appendChildren([this.image, this.info]);
+  }
+
+  updateContent(painting: Painting) {
+    const { name, author, year, imageSrc } = painting;
+
+    this.image.setAttribute("src", `${IMAGES_BASE_URL}/${imageSrc}`);
+    this.image.setAttribute("alt", name);
+
+    this.info.clear();
+    [name, author, year].forEach((value) => {
+      this.info.append(p({ text: value }));
+    });
+  }
+}

--- a/src/features/game/stats/RoundStats.module.css
+++ b/src/features/game/stats/RoundStats.module.css
@@ -2,8 +2,12 @@
   display: grid;
   gap: 1rem;
 
-  @container (width < 500px) {
-    grid-template-columns: 1fr;
+  grid-template-rows: min-content 1fr max-content;
+
+  height: 100%;
+
+  @media (orientation: landscape) and (height < 400px) {
+    grid-template-rows: 1fr max-content;
   }
 }
 
@@ -19,7 +23,6 @@
   flex-direction: column;
   gap: 1.2rem;
 
-  height: min(400px, 80vh);
   overflow-y: scroll;
 
   /* to make place for scrollbar */

--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -1,16 +1,19 @@
 import Component from "../../../shared/Component";
 import Modal from "../../../ui/modal/Modal";
-import Button from "../../../ui/button/Button";
+import ArtworkMiniature from "./ArtworkMiniature";
 import SentencesList, { SentencesListType } from "./SentencesList";
+import Button from "../../../ui/button/Button";
+import { div } from "../../../ui/tags";
 
-import { Observer, Publisher } from "../../../shared/Observer";
 import RoundState from "../model/RoundState";
+import { Observer, Publisher } from "../../../shared/Observer";
 import { Stage, StageStatus } from "../types";
 
 import styles from "./RoundStats.module.css";
-import { div } from "../../../ui/tags";
 
 export default class RoundStats extends Component implements Observer {
+  private artwork: ArtworkMiniature;
+
   private knownSentencesList: SentencesList;
 
   private unknownSentencesList: SentencesList;
@@ -29,10 +32,12 @@ export default class RoundStats extends Component implements Observer {
       styles.continue,
     );
 
+    this.artwork = new ArtworkMiniature(this.roundState.state.painting);
     this.knownSentencesList = new SentencesList(SentencesListType.SOLVED);
     this.unknownSentencesList = new SentencesList(SentencesListType.UNSOLVED);
 
     this.appendChildren([
+      this.artwork,
       div(
         { className: styles.sentences },
         this.knownSentencesList,
@@ -52,6 +57,7 @@ export default class RoundStats extends Component implements Observer {
         else unsolvedStages.push(stage);
       });
 
+      this.artwork.updateContent(publisher.state.painting);
       this.knownSentencesList.fillList(solvedStages);
       this.unknownSentencesList.fillList(unsolvedStages);
 

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,7 +1,7 @@
 import { Stage, Word } from "../features/game/types";
 import Component from "./Component";
 
-const IMAGES_BASE_URL =
+export const IMAGES_BASE_URL =
   "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";
 const ROW_WIDTH = 728;
 const CONCAVE_WIDTH = 10;

--- a/src/ui/modal/Modal.module.css
+++ b/src/ui/modal/Modal.module.css
@@ -15,6 +15,7 @@ body:has(.modal[open]) {
   border-radius: var(--border-radius-sm);
 
   min-width: min(750px, 95vw);
+  height: 80vh;
 }
 
 .modal::backdrop {


### PR DESCRIPTION
## What was done
Introduced a feature on the statistics window to display a miniature version of the artwork assembled during the current round. 

## Reason for the change
This visual element acts as both a reward and a recap of the player's achievement in piecing together the puzzle-like sentences. It serves to enhance the player's sense of accomplishment and visually connects their linguistic success with the artwork they've uncovered.