### PR TITLE
fix: PZ-90 Update unsubscribing function

### DIFF
--- a/src/app/state/StatePublisher.ts
+++ b/src/app/state/StatePublisher.ts
@@ -31,9 +31,7 @@ export default class State<T> implements Publisher {
   }
 
   unsubscribe(subscriber: Observer): void {
-    const targetIndex = this.subscribers.indexOf(subscriber);
-
-    this.subscribers.splice(targetIndex, 1);
+    this.subscribers = this.subscribers.filter((item) => item !== subscriber);
   }
 
   notifySubscribers(): void {


### PR DESCRIPTION
## What was done
Fixed the bug that prevented the toggling of visibility for hints after a user finished the first round.

## Reason for the change
The issue arose because the `splice` and `indexOf` methods were used to delete subscribers. When `indexOf` returned -1, indicating that there was no such subscriber, the `splice` method deleted the last item in the array of subscribers. As a result, hints and hint controls were also unsubscribed.

## Implementation details
Replaced `splice` with `filter` to correct this behavior. I considered adding a guard clause to prevent passing -1 to the `splice` function but ultimately decided that the `filter` solution looked more readable.