### PR TITLE
feat: PZ-27 Save last visited or completed round

### DIFF
--- a/src/app/state/StatePublisher.ts
+++ b/src/app/state/StatePublisher.ts
@@ -20,9 +20,9 @@ export default class State<T> implements Publisher {
     return this.defaultState;
   }
 
-  saveState() {
+  saveState(state = this.state) {
     if (this.key) {
-      localStorage.setItem(this.key, JSON.stringify(this.state));
+      localStorage.setItem(this.key, JSON.stringify(state));
     }
   }
 

--- a/src/features/game/controls/RoundControls.ts
+++ b/src/features/game/controls/RoundControls.ts
@@ -51,6 +51,15 @@ export default class RoundControls extends Component implements Observer {
     ]);
 
     this.addListener("change", this.handleDifficultySelection.bind(this));
+
+    RoundControls.selectOption(
+      this.difficultySelect,
+      this.roundSettings.state.difficultyLevel,
+    );
+    RoundControls.selectOption(
+      this.roundSelect,
+      this.roundSettings.state.roundNumber,
+    );
   }
 
   update(publisher: Publisher) {

--- a/src/features/game/model/RoundSettings.ts
+++ b/src/features/game/model/RoundSettings.ts
@@ -23,6 +23,12 @@ export default class RoundSettings extends State<RoundSettingsData> {
 
   updateSetting(setting: keyof RoundSettingsData, value: number) {
     this.state[setting] = value;
+
+    // when the difficulty level is updated, reset to the first round, as the number of rounds differs between difficulties
+    if (setting === "difficultyLevel") {
+      this.state.roundNumber = 0;
+    }
+
     this.updateRoundsAmount();
     this.notifySubscribers();
   }

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -34,7 +34,8 @@ function prepareRound(difficulty: number, round: number): Round {
 
 export default class RoundState extends State<Round> implements Observer {
   constructor(private roundSettings: RoundSettings) {
-    super(prepareRound(0, 0));
+    const { difficultyLevel, roundNumber } = roundSettings.state;
+    super(prepareRound(difficultyLevel, roundNumber));
 
     this.roundSettings.subscribe(this);
   }
@@ -76,6 +77,9 @@ export default class RoundState extends State<Round> implements Observer {
 
   startRound(): void {
     this.startStage(0);
+
+    // This allows users to resume the game from the last visited round instead of the last completed one. Remove this line if it is not needed
+    this.roundSettings.saveState();
   }
 
   moveCard(action: MoveCardAction): void {
@@ -120,6 +124,11 @@ export default class RoundState extends State<Round> implements Observer {
     );
 
     this.notifySubscribers();
+
+    // This will allow users to start the next round when they return, if they close the app before progressing.
+    if (this.isRoundCompleted()) {
+      this.roundSettings.saveNextRound();
+    }
   }
 
   autocompleteStage(): void {
@@ -134,6 +143,11 @@ export default class RoundState extends State<Round> implements Observer {
     this.setStageStatus(StageStatus.AUTOCOMPLETED);
 
     this.notifySubscribers();
+
+    // This will allow users to start the next round when they return, if they close the app before progressing.
+    if (this.isRoundCompleted()) {
+      this.roundSettings.saveNextRound();
+    }
   }
 
   setStageStatus(updatedStatus: StageStatus): void {


### PR DESCRIPTION
## What was done
Implemented a feature to save the player's last completed round in local storage. 

## Reason for the change
These changes ensure continuous gameplay across sessions.

## Implementation details
Upon restarting the game, it automatically begins with the next round in sequence. If the player has completed the last round of a difficulty level, the game starts at the first round of the next difficulty level. If the player finishes the last round of the highest difficulty level, the game will restart from the first round of the first difficulty level. Additionally, if the player has started a round but didn't finish, the game will resume from that point.
