### PR TITLE
fix: PZ-85 Reset rating component

### DIFF
--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -84,6 +84,7 @@ export default class RoundStats extends Component implements Observer {
       () => i({ className: "bi bi-star-fill" }),
     );
 
+    this.rating.clear();
     this.rating.appendChildren(filledStars.concat(emptyStars));
   }
 }


### PR DESCRIPTION
## What was done
Reset the rating component, since ratings from each completed round were appending.

