### PR TITLE
fix: PZ-97 Update the rating after subsequent attempts

### DIFF
--- a/src/features/game/model/RoundSettings.ts
+++ b/src/features/game/model/RoundSettings.ts
@@ -95,18 +95,29 @@ export default class RoundSettings extends State<RoundSettingsData> {
   /* When a user has completed a round but closes the app instead of moving on to the next one, we still want to show them the next round when they return, rather than the one they have already completed.
    */
   handleCompletedRound(roundResult: RoundResult) {
-    const { difficultyLevel } = this.state.currentLevel;
-    const { roundNumber, rating } = roundResult;
-
-    const roundsArray = this.state.completed.get(difficultyLevel);
-
-    if (roundsArray) {
-      roundsArray.push({ roundNumber, rating });
-    } else {
-      this.state.completed.set(difficultyLevel, [{ roundNumber, rating }]);
-    }
+    this.updateCompletedRoundRating(roundResult);
 
     this.saveState(this.getIncrementedRound());
+  }
+
+  updateCompletedRoundRating(roundResult: RoundResult) {
+    const { difficultyLevel } = this.state.currentLevel;
+    const { roundNumber, rating: updatedRating } = roundResult;
+
+    const rounds = this.state.completed.get(difficultyLevel) ?? [];
+
+    const targetRound = rounds.find((item) => item.roundNumber === roundNumber);
+
+    // there is no point to save lower rating
+    if (targetRound && updatedRating > targetRound.rating) {
+      targetRound.rating = updatedRating;
+    }
+
+    if (!targetRound) {
+      this.state.completed.set(difficultyLevel, [
+        { roundNumber, rating: updatedRating },
+      ]);
+    }
   }
 
   getSavedRoundRating(difficultyLevel: number, roundNumber: number): number {

--- a/src/features/game/model/RoundSettings.ts
+++ b/src/features/game/model/RoundSettings.ts
@@ -100,13 +100,11 @@ export default class RoundSettings extends State<RoundSettingsData> {
     this.saveState(this.getIncrementedRound());
   }
 
-  updateCompletedRoundRating(roundResult: RoundResult) {
+  private updateCompletedRoundRating(roundResult: RoundResult) {
     const { difficultyLevel } = this.state.currentLevel;
     const { roundNumber, rating: updatedRating } = roundResult;
 
-    const rounds = this.state.completed.get(difficultyLevel) ?? [];
-
-    const targetRound = rounds.find((item) => item.roundNumber === roundNumber);
+    const targetRound = this.getSavedRound(difficultyLevel, roundNumber);
 
     // there is no point to save lower rating
     if (targetRound && updatedRating > targetRound.rating) {
@@ -120,12 +118,17 @@ export default class RoundSettings extends State<RoundSettingsData> {
     }
   }
 
-  getSavedRoundRating(difficultyLevel: number, roundNumber: number): number {
-    const rating = this.state.completed
-      .get(difficultyLevel)
-      ?.find((item) => item.roundNumber === roundNumber)?.rating;
+  private getSavedRound(difficultyLevel: number, roundNumber: number) {
+    const rounds = this.state.completed.get(difficultyLevel) ?? [];
+    return rounds.find((item) => item.roundNumber === roundNumber);
+  }
 
-    return rating || 0;
+  getSavedRoundRating(difficultyLevel: number, roundNumber: number): number {
+    const targetRound = this.getSavedRound(difficultyLevel, roundNumber);
+
+    if (targetRound) return targetRound.rating;
+
+    return 0;
   }
 
   // redefine because maps get stringified to empty objects


### PR DESCRIPTION
## What Was Done
Fixed the bug related to updating the round rating after subsequent attempts.

## Reason for the Change
Fixes #97

## Implementation Details
Added a check to determine if the round in question was already saved or completed.