### PR TITLE
refactor: PZ-77 Extract the drag-and-drop functionality into a separate class

### DIFF
--- a/src/features/game/card/Draggable.ts
+++ b/src/features/game/card/Draggable.ts
@@ -15,7 +15,6 @@ export default abstract class Draggable extends Component {
 
   constructor(
     className: string,
-
     private droppableClassName: string,
   ) {
     super({
@@ -30,7 +29,7 @@ export default abstract class Draggable extends Component {
 
   abstract dropCancelHandler(): void;
 
-  abstract dropSwapHanlder(): void;
+  abstract dropSwapHanlder(dropTarget: HTMLElement): void;
 
   abstract clickHandler(): void;
 
@@ -114,12 +113,11 @@ export default abstract class Draggable extends Component {
     const dropTarget = this.findDroppable(e.clientX, e.clientY);
 
     if (!dropTarget) {
-      // basically, nothing happens, but we need to synchronize the UI with the state because we snapped the card from the row, leaving a gap
       this.dropCancelHandler();
     }
 
     if (dropTarget) {
-      this.dropSwapHanlder();
+      this.dropSwapHanlder(dropTarget);
     }
   }
 

--- a/src/features/game/card/Draggable.ts
+++ b/src/features/game/card/Draggable.ts
@@ -1,0 +1,155 @@
+import Component from "../../../shared/Component";
+
+const DRAG_THRESHOLD = 2;
+
+export default abstract class Draggable extends Component {
+  private clientX: number = 0;
+
+  private clientY: number = 0;
+
+  private shiftX: number = 0;
+
+  private shiftY: number = 0;
+
+  private lastDropTarget: HTMLElement | null = null;
+
+  constructor(
+    className: string,
+
+    private droppableClassName: string,
+  ) {
+    super({
+      className,
+    });
+
+    this.getElement().addEventListener(
+      "mousedown",
+      this.mouseDownHandler.bind(this),
+    );
+  }
+
+  abstract dropCancelHandler(): void;
+
+  abstract dropSwapHanlder(): void;
+
+  abstract clickHandler(): void;
+
+  private mouseDownHandler(e: MouseEvent): void {
+    // track coordinates to tell apart clicks from drags
+    this.clientX = e.clientX;
+    this.clientY = e.clientY;
+
+    const element = this.getElement();
+    const { left, top, height, width } = element.getBoundingClientRect();
+
+    // keep track of these coordinates to adjust the dragging point to any location on the element. otherwise, the center of the element will move to the cursor when clicked.
+    this.shiftX = e.clientX - left;
+    this.shiftY = e.clientY - top;
+
+    // snap the element from the row
+    const elementStyles = {
+      position: "absolute",
+      zIndex: "1000",
+      cursor: "grabbing",
+      height: `${height}px`,
+      width: `${width}px`,
+    };
+
+    this.setInlineStyles(elementStyles);
+    document.body.append(element);
+
+    // follow the cursor
+    this.moveAt(e.pageX, e.pageY);
+    const mouseMoveBound = this.mouseMoveHandler.bind(this);
+    window.addEventListener("mousemove", mouseMoveBound);
+
+    // adding an event listener this way is justified here, since we need exactly one 'mouseup' listener, which will be removed after triggering
+    element.onmouseup = (event: MouseEvent) => {
+      this.mouseUpHandler(event);
+
+      // stops dragging
+      window.removeEventListener("mousemove", mouseMoveBound);
+
+      // deletes itself
+      element.onmouseup = null;
+    };
+  }
+
+  private mouseMoveHandler(e: MouseEvent): void {
+    this.moveAt(e.pageX, e.pageY);
+
+    const dropTarget = this.findDroppable(e.clientX, e.clientY);
+
+    if (!(dropTarget instanceof HTMLElement)) return;
+
+    if (this.lastDropTarget !== dropTarget) {
+      // leaving (cell -> null or other cell )
+      if (this.lastDropTarget) {
+        this.resetDropTargetHoverStyles();
+      }
+      this.lastDropTarget = dropTarget;
+
+      // entering (null -> cell)
+      this.setDropTargetHoverStyles();
+    }
+  }
+
+  private mouseUpHandler(e: MouseEvent) {
+    // otherwise cell stays highlighted after clicking on previously dragged card
+    this.resetDropTargetHoverStyles();
+
+    const isDrag =
+      Math.abs(this.clientX - e.clientX) > DRAG_THRESHOLD ||
+      Math.abs(this.clientY - e.clientY) > DRAG_THRESHOLD;
+
+    if (isDrag) this.dropHandler(e);
+    else this.clickHandler();
+
+    // absolutely positioned card always gets destroyed
+    this.destroy();
+  }
+
+  private dropHandler(e: MouseEvent) {
+    // cannot use this.lastDropTarget here, because drop canceling wouldn't work
+    const dropTarget = this.findDroppable(e.clientX, e.clientY);
+
+    if (!dropTarget) {
+      // basically, nothing happens, but we need to synchronize the UI with the state because we snapped the card from the row, leaving a gap
+      this.dropCancelHandler();
+    }
+
+    if (dropTarget) {
+      this.dropSwapHanlder();
+    }
+  }
+
+  private moveAt(pageX: number, pageY: number): void {
+    const card = this.getElement();
+
+    card.style.left = `${pageX - this.shiftX}px`;
+    card.style.top = `${pageY - this.shiftY}px`;
+  }
+
+  private setDropTargetHoverStyles() {
+    if (this.lastDropTarget) {
+      this.lastDropTarget.style.background = "var(--color-brand-200)";
+    }
+  }
+
+  private resetDropTargetHoverStyles() {
+    if (this.lastDropTarget) {
+      this.lastDropTarget.style.background = "";
+    }
+  }
+
+  // NOTE: I don't know about this, but eslint insists
+  private findDroppable(clientX: number, clientY: number): HTMLElement | null {
+    // find the target cell underneath the dragged card
+    const elementsBelow = document.elementsFromPoint(clientX, clientY);
+    const dropTarget = elementsBelow.find((element) =>
+      element.classList.contains(this.droppableClassName),
+    );
+
+    return dropTarget instanceof HTMLElement ? dropTarget : null;
+  }
+}

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -1,5 +1,5 @@
 import Component from "../../../shared/Component";
-import Draggable from "./Draggable";
+import Draggable from "../../../shared/Draggable";
 import { div, span } from "../../../ui/tags";
 
 import { Word, MoveCardAction, RowType } from "../types";

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -1,27 +1,14 @@
 import Component from "../../../shared/Component";
+import Draggable from "./Draggable";
+import { div, span } from "../../../ui/tags";
 
 import { Word, MoveCardAction, RowType } from "../types";
-
-import { div, span } from "../../../ui/tags";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";
 import rowStyles from "../fields/Row.module.css";
 
-const DRAG_THRESHOLD = 2;
-
-// TODO: this class is too bloated. extract the Drag & Drop functionality into the Draggable class
-export default class WordCard extends Component {
-  private clientX: number = 0;
-
-  private clientY: number = 0;
-
-  private shiftX: number = 0;
-
-  private shiftY: number = 0;
-
-  private lastDropTarget: HTMLElement | null = null;
-
+export default class WordCard extends Draggable {
   private textSpan: Component;
 
   constructor(
@@ -32,16 +19,11 @@ export default class WordCard extends Component {
   ) {
     const lastWordClassName = data.isLast ? styles.last : "";
     const firstWordClassName = data.correctPosition === 0 ? styles.first : "";
-    const classNames = [styles.word, firstWordClassName, lastWordClassName];
-
-    super({
-      className: classNames.join(" "),
-    });
-
-    this.getElement().addEventListener(
-      "mousedown",
-      this.mouseDownHandler.bind(this),
+    const className = [styles.word, firstWordClassName, lastWordClassName].join(
+      " ",
     );
+
+    super(className, rowStyles.cell);
 
     this.textSpan = span({ className: styles.text, text: this.data.text });
     this.configure();
@@ -64,13 +46,8 @@ export default class WordCard extends Component {
     });
   }
 
-  /*
-   * The math can be tricky: the width of the card is specified in percentages,
-   * but the background-position in percentages behaves differently than when
-   * it's set in pixels. It's easier to calculate the actual width of the card
-   * in pixels rather than dealing with the current setup.
-   */
-  /* TODO: Change the formula to avoid excessive calculations and to work with percentages. */
+  // The math can be tricky: the width of the card is specified in percentages, but the background-position in percentages behaves differently than when it's set in pixels. It's easier to calculate the actual width of the card in pixels rather than dealing with the current setup.
+  // TODO: Change the formula to avoid excessive calculations and to work with percentages. */
   // FIXME: frequent updating causes blinking
   public calculateBackgroundPositions(rowWidth: number, rowHeight: number) {
     const [content, convex] = this.getChildren();
@@ -105,82 +82,7 @@ export default class WordCard extends Component {
     this.textSpan.setInlineStyles({ transitionDelay: `${transitionDelay}s` });
   }
 
-  private mouseDownHandler(e: MouseEvent): void {
-    // track coordinates to tell apart clicks from drags
-    this.clientX = e.clientX;
-    this.clientY = e.clientY;
-
-    const card = this.getElement();
-    const { left, top, height, width } = card.getBoundingClientRect();
-
-    // keep track of these coordinates to adjust the dragging point to any location on the card. otherwise, the center of the card will move to the cursor when clicked.
-    this.shiftX = e.clientX - left;
-    this.shiftY = e.clientY - top;
-
-    // snap the card from the row
-    const cardStyles = {
-      position: "absolute",
-      zIndex: "1000",
-      cursor: "grabbing",
-      height: `${height}px`,
-      width: `${width}px`,
-    };
-
-    this.setInlineStyles(cardStyles);
-    document.body.append(card);
-
-    // follow the cursor
-    this.moveAt(e.pageX, e.pageY);
-    const mouseMoveBound = this.mouseMoveHandler.bind(this);
-    window.addEventListener("mousemove", mouseMoveBound);
-
-    // adding an event listener this way is justified here, since we need exactly one 'mouseup' listener, which will be removed after triggering
-    card.onmouseup = (event: MouseEvent) => {
-      this.mouseUpHandler(event);
-
-      // stops dragging
-      window.removeEventListener("mousemove", mouseMoveBound);
-
-      // deletes itself
-      card.onmouseup = null;
-    };
-  }
-
-  private mouseMoveHandler(e: MouseEvent): void {
-    this.moveAt(e.pageX, e.pageY);
-
-    const dropTarget = WordCard.findDroppableCell(e.clientX, e.clientY);
-
-    if (!(dropTarget instanceof HTMLElement)) return;
-
-    if (this.lastDropTarget !== dropTarget) {
-      // leaving (cell -> null or other cell )
-      if (this.lastDropTarget) {
-        this.resetDropTargetHoverStyles();
-      }
-      this.lastDropTarget = dropTarget;
-
-      // entering (null -> cell)
-      this.setDropTargetHoverStyles();
-    }
-  }
-
-  private mouseUpHandler(e: MouseEvent) {
-    // otherwise cell stays highlighted after clicking on previously dragged card
-    this.resetDropTargetHoverStyles();
-
-    const isDrag =
-      Math.abs(this.clientX - e.clientX) > DRAG_THRESHOLD ||
-      Math.abs(this.clientY - e.clientY) > DRAG_THRESHOLD;
-
-    if (isDrag) this.dropHandler(e);
-    else this.clickHandler();
-
-    // absolutely positioned card always gets destroyed
-    this.destroy();
-  }
-
-  private clickHandler() {
+  clickHandler() {
     // clicking always move to the opposite word
     const oppositeRow =
       this.initRowType === RowType.PICK ? RowType.ASSEMBLE : RowType.PICK;
@@ -198,70 +100,32 @@ export default class WordCard extends Component {
     this.actionHandler(action);
   }
 
-  private dropHandler(e: MouseEvent) {
-    // cannot use this.lastDropTarget here, because drop canceling wouldn't work
-    const dropTarget = WordCard.findDroppableCell(e.clientX, e.clientY);
+  // basically, nothing happens, but we need to synchronize the UI with the state because we snapped the card from the row, leaving a gap
+  dropCancelHandler(): void {
+    const action: MoveCardAction = {
+      type: "drop/cancel",
+      payload: {
+        indexFrom: +assertNonNull(this.getElement().dataset.index),
+        rowFrom: this.initRowType,
+        indexTo: +assertNonNull(this.getElement().dataset.index),
+        rowTo: this.initRowType,
+      },
+    };
 
-    if (!dropTarget) {
-      // basically, nothing happens, but we need to synchronize the UI with the state because we snapped the card from the row, leaving a gap
-      const action: MoveCardAction = {
-        type: "drop/cancel",
-        payload: {
-          indexFrom: +assertNonNull(this.getElement().dataset.index),
-          rowFrom: this.initRowType,
-          indexTo: +assertNonNull(this.getElement().dataset.index),
-          rowTo: this.initRowType,
-        },
-      };
-
-      this.actionHandler(action);
-    }
-
-    if (dropTarget) {
-      const action: MoveCardAction = {
-        type: "drop/swap",
-        payload: {
-          indexFrom: +assertNonNull(this.getElement().dataset.index),
-          rowFrom: this.initRowType,
-          indexTo: +assertNonNull(dropTarget.dataset.index),
-          // NOTE: had to use type casting, maybe there is an other way, but doesn't seem like it
-          rowTo: assertNonNull(dropTarget.dataset.type as RowType),
-        },
-      };
-      this.actionHandler(action);
-    }
+    this.actionHandler(action);
   }
 
-  private moveAt(pageX: number, pageY: number): void {
-    const card = this.getElement();
-
-    card.style.left = `${pageX - this.shiftX}px`;
-    card.style.top = `${pageY - this.shiftY}px`;
-  }
-
-  private setDropTargetHoverStyles() {
-    if (this.lastDropTarget) {
-      this.lastDropTarget.style.background = "var(--color-brand-200)";
-    }
-  }
-
-  private resetDropTargetHoverStyles() {
-    if (this.lastDropTarget) {
-      this.lastDropTarget.style.background = "";
-    }
-  }
-
-  // NOTE: I don't know about this, but eslint insists
-  private static findDroppableCell(
-    clientX: number,
-    clientY: number,
-  ): HTMLElement | null {
-    // find the target cell underneath the dragged card
-    const elementsBelow = document.elementsFromPoint(clientX, clientY);
-    const dropTarget = elementsBelow.find((element) =>
-      element.classList.contains(rowStyles.cell),
-    );
-
-    return dropTarget instanceof HTMLElement ? dropTarget : null;
+  dropSwapHanlder(dropTarget: HTMLElement): void {
+    const action: MoveCardAction = {
+      type: "drop/swap",
+      payload: {
+        indexFrom: +assertNonNull(this.getElement().dataset.index),
+        rowFrom: this.initRowType,
+        indexTo: +assertNonNull(dropTarget.dataset.index),
+        // NOTE: had to use type casting, maybe there is an other way, but doesn't seem like it
+        rowTo: assertNonNull(dropTarget.dataset.type as RowType),
+      },
+    };
+    this.actionHandler(action);
   }
 }

--- a/src/shared/Draggable.ts
+++ b/src/shared/Draggable.ts
@@ -1,4 +1,4 @@
-import Component from "../../../shared/Component";
+import Component from "./Component";
 
 const DRAG_THRESHOLD = 2;
 


### PR DESCRIPTION
## What Was Done
Extracted the drag-and-drop functionality into the `Draggable` class.

## Reason for the Change
These changes aim to make the drag-and-drop functionality more reusable and to reduce the bloat in the `WordCard` class.

## Implementation Details
The new `Draggable` class is an abstract class, meaning it cannot be instantiated but can only be extended.