### PR TITLE
fix: PZ-80 Stop the card background from flickering

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -53,7 +53,9 @@ export default class App {
       {
         path: Pages.GAME,
         callback: () => {
-          this.appLayout.setContent(new GamePage());
+          const gamePage = new GamePage();
+          this.appLayout.setContent(gamePage);
+          gamePage.init();
         },
       },
     ];

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -2,6 +2,8 @@ import Component from "../../../shared/Component";
 import Draggable from "../../../shared/Draggable";
 import { div, span } from "../../../ui/tags";
 
+import HintSettings from "../model/HintSettings";
+import RoundState from "../model/RoundState";
 import { Word, MoveCardAction, RowType } from "../types";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
@@ -13,9 +15,9 @@ export default class WordCard extends Draggable {
 
   constructor(
     private data: Word,
-    private actionHandler: (action: MoveCardAction) => void,
-    private initRowType: RowType,
-    private isBackgroundDisplayed: boolean | null,
+    private rowData: { type: RowType; width: number; height: number },
+    private roundState: RoundState,
+    private hintSettings: HintSettings,
   ) {
     const lastWordClassName = data.isLast ? styles.last : "";
     const firstWordClassName = data.correctPosition === 0 ? styles.first : "";
@@ -34,7 +36,8 @@ export default class WordCard extends Draggable {
     const convex = div({ className: styles.convex });
 
     this.appendChildren([content, convex]);
-    this.setBackground(this.isBackgroundDisplayed);
+    this.setBackground(this.hintSettings.state.background);
+    this.calculateBackgroundPositions(this.rowData.width, this.rowData.height);
   }
 
   setBackground(isHintEnabled: boolean | null) {
@@ -48,14 +51,13 @@ export default class WordCard extends Draggable {
 
   // The math can be tricky: the width of the card is specified in percentages, but the background-position in percentages behaves differently than when it's set in pixels. It's easier to calculate the actual width of the card in pixels rather than dealing with the current setup.
   // TODO: Change the formula to avoid excessive calculations and to work with percentages. */
-  // FIXME: frequent updating causes blinking
   public calculateBackgroundPositions(rowWidth: number, rowHeight: number) {
     const [content, convex] = this.getChildren();
 
     const rowOffsetY = this.data.stage * rowHeight;
     const contentOffsetX = (rowWidth * this.data.offset) / 100;
 
-    const convexHeight = convex.getElement().getBoundingClientRect().height;
+    const convexHeight = window.matchMedia("(width<500px)").matches ? 10 : 20;
 
     // the convex starts at the same place as the next piece (in pixels)
     const convexOffsetX =
@@ -85,19 +87,19 @@ export default class WordCard extends Draggable {
   clickHandler() {
     // clicking always move to the opposite word
     const oppositeRow =
-      this.initRowType === RowType.PICK ? RowType.ASSEMBLE : RowType.PICK;
+      this.rowData.type === RowType.PICK ? RowType.ASSEMBLE : RowType.PICK;
 
     const action: MoveCardAction = {
       type: "click/move",
       payload: {
         indexFrom: +assertNonNull(this.getElement().dataset.index),
-        rowFrom: this.initRowType,
+        rowFrom: this.rowData.type,
         indexTo: -1, // not relevant
         rowTo: oppositeRow,
       },
     };
 
-    this.actionHandler(action);
+    this.roundState.moveCard(action);
   }
 
   // basically, nothing happens, but we need to synchronize the UI with the state because we snapped the card from the row, leaving a gap
@@ -106,13 +108,13 @@ export default class WordCard extends Draggable {
       type: "drop/cancel",
       payload: {
         indexFrom: +assertNonNull(this.getElement().dataset.index),
-        rowFrom: this.initRowType,
+        rowFrom: this.rowData.type,
         indexTo: +assertNonNull(this.getElement().dataset.index),
-        rowTo: this.initRowType,
+        rowTo: this.rowData.type,
       },
     };
 
-    this.actionHandler(action);
+    this.roundState.moveCard(action);
   }
 
   dropSwapHanlder(dropTarget: HTMLElement): void {
@@ -120,12 +122,12 @@ export default class WordCard extends Draggable {
       type: "drop/swap",
       payload: {
         indexFrom: +assertNonNull(this.getElement().dataset.index),
-        rowFrom: this.initRowType,
+        rowFrom: this.rowData.type,
         indexTo: +assertNonNull(dropTarget.dataset.index),
         // NOTE: had to use type casting, maybe there is an other way, but doesn't seem like it
         rowTo: assertNonNull(dropTarget.dataset.type as RowType),
       },
     };
-    this.actionHandler(action);
+    this.roundState.moveCard(action);
   }
 }

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -4,6 +4,7 @@ import { div, span } from "../../../ui/tags";
 
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
+import type { RowData } from "../fields/Row";
 import { Word, MoveCardAction, RowType } from "../types";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
@@ -15,7 +16,7 @@ export default class WordCard extends Draggable {
 
   constructor(
     private data: Word,
-    private rowData: { type: RowType; width: number; height: number },
+    private rowData: RowData,
     private roundState: RoundState,
     private hintSettings: HintSettings,
   ) {

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -117,7 +117,7 @@ export default class WordCard extends Draggable {
     this.roundState.moveCard(action);
   }
 
-  dropSwapHanlder(dropTarget: HTMLElement): void {
+  dropSwapHandler(dropTarget: HTMLElement): void {
     const action: MoveCardAction = {
       type: "drop/swap",
       payload: {

--- a/src/features/game/fields/AssembleRow.ts
+++ b/src/features/game/fields/AssembleRow.ts
@@ -1,0 +1,67 @@
+import Row from "./Row";
+import RoundState from "../model/RoundState";
+import HintSettings from "../model/HintSettings";
+
+import { Publisher } from "../../../shared/Observer";
+import { RowType, StageStatus } from "../types";
+
+import styles from "./Row.module.css";
+
+export default class AssembleRow extends Row {
+  constructor(
+    stageNumber: number,
+    roundState: RoundState,
+    hintSettings: HintSettings,
+  ) {
+    super(RowType.ASSEMBLE, stageNumber, roundState, hintSettings);
+
+    if (stageNumber === 0) {
+      this.activateRow();
+    }
+  }
+
+  update(publisher: Publisher): void {
+    if (publisher instanceof RoundState) {
+      if (this.stageNumber !== publisher.state.currentStage) {
+        this.deactivateRow();
+        return;
+      }
+
+      if (this.roundId !== publisher.state.id) return;
+
+      const { assembleArea } = publisher.state.content;
+      this.activateRow();
+      this.updateCells(assembleArea);
+      this.updateStatusStyles(
+        this.roundState.state.stages[this.roundState.state.currentStage].status,
+      );
+    }
+
+    if (publisher instanceof HintSettings) {
+      this.toggleRowBackgrounds(publisher.state.background);
+    }
+  }
+
+  updateStatusStyles(status: StageStatus) {
+    // reset styles
+    this.removeClass(styles.correct);
+    this.removeClass(styles.incorrect);
+
+    if (status !== StageStatus.NOT_COMPLETED) this.addClass(styles[status]);
+
+    if ([StageStatus.CORRECT, StageStatus.AUTOCOMPLETED].includes(status)) {
+      this.toggleRowBackgrounds(true);
+
+      // solved rows always display background, so the row doesn't have to be affected by hint settings anymore
+      this.hintSettings.unsubscribe(this);
+    }
+  }
+
+  activateRow() {
+    this.addClass(styles.active);
+  }
+
+  deactivateRow() {
+    this.removeClass(styles.active);
+  }
+}

--- a/src/features/game/fields/GameField.ts
+++ b/src/features/game/fields/GameField.ts
@@ -42,18 +42,22 @@ export default class GameField extends Component implements Observer {
       }
 
       this.roundId = id;
+
       this.fadeAwayAllCards(publisher.isRoundCompleted());
     }
   }
 
-  // FIXME: last row doesn't fade away
+  // I tried to fade the cards from the row class, but when a player auto-completes the last round, the animation starts before the DOM updates the last row (I think). So, the very last card doesn't fade and is already hidden. Maybe there's a better solution than using a timeout
+
   private fadeAwayAllCards(isRoundCompleted: boolean) {
     if (isRoundCompleted) {
-      const cards = findAllInstancesOf(WordCard, this);
+      setTimeout(() => {
+        const cards = findAllInstancesOf(WordCard, this);
 
-      cards.forEach((card, index) => {
-        card.fadeAwayCardText(index / ANIMATION_DELAY_COEFFICIENT);
-      });
+        cards.forEach((card, index) => {
+          card.fadeAwayCardText(index / ANIMATION_DELAY_COEFFICIENT);
+        });
+      }, 100);
     }
   }
 

--- a/src/features/game/fields/PickRow.ts
+++ b/src/features/game/fields/PickRow.ts
@@ -1,0 +1,31 @@
+import { Publisher } from "../../../shared/Observer";
+import HintSettings from "../model/HintSettings";
+import RoundState from "../model/RoundState";
+import { RowType } from "../types";
+import Row from "./Row";
+
+export default class PickRow extends Row {
+  constructor(
+    public stageNumber: number,
+    roundState: RoundState,
+    hintSettings: HintSettings,
+  ) {
+    super(RowType.PICK, stageNumber, roundState, hintSettings);
+  }
+
+  update(publisher: Publisher): void {
+    if (publisher instanceof RoundState) {
+      if (this.stageNumber !== publisher.state.currentStage) return;
+
+      if (this.roundId !== publisher.state.id) return;
+
+      const { pickArea } = publisher.state.content;
+
+      this.updateCells(pickArea);
+    }
+
+    if (publisher instanceof HintSettings) {
+      this.toggleRowBackgrounds(publisher.state.background);
+    }
+  }
+}

--- a/src/features/game/fields/WordsPicker.module.css
+++ b/src/features/game/fields/WordsPicker.module.css
@@ -4,6 +4,10 @@
   box-shadow: var(--shadow-sm);
 
   width: 100%;
-  height: 40px;
   transition: all 0.3s;
+
+  /* row */
+  & > div {
+    height: 100%;
+  }
 }

--- a/src/pages/game/GamePage.ts
+++ b/src/pages/game/GamePage.ts
@@ -56,8 +56,8 @@ export default class GamePage extends Component {
   private configure() {
     const warning = new SmallScreenWarningCard(this.smallScreenSettings);
     const controls = this.configureControls();
-    const hints = this.configurHints();
-    const fields = this.configureFieds();
+    const hints = this.configureHints();
+    const fields = this.configureFields();
 
     this.appendChildren([warning, controls, hints, ...fields, this.modal]);
 
@@ -65,7 +65,7 @@ export default class GamePage extends Component {
     this.hintSettings.notifySubscribers();
   }
 
-  private configureFieds() {
+  private configureFields() {
     const gameField = new GameField(this.roundState, this.hintSettings);
     const paintingInfo = new PaintingInfo(this.roundState);
     const wordsPicker = new WordsPicker(this.roundState, this.hintSettings);
@@ -74,7 +74,7 @@ export default class GamePage extends Component {
     return [gameField, paintingInfo, wordsPicker, roundControls];
   }
 
-  private configurHints() {
+  private configureHints() {
     const translationHint = new TranslationHint(
       this.roundState,
       this.hintSettings,
@@ -107,5 +107,10 @@ export default class GamePage extends Component {
     );
 
     return controls;
+  }
+
+  init() {
+    this.roundState.startRound();
+    this.hintSettings.notifySubscribers();
   }
 }

--- a/src/shared/Draggable.ts
+++ b/src/shared/Draggable.ts
@@ -29,7 +29,7 @@ export default abstract class Draggable extends Component {
 
   abstract dropCancelHandler(): void;
 
-  abstract dropSwapHanlder(dropTarget: HTMLElement): void;
+  abstract dropSwapHandler(dropTarget: HTMLElement): void;
 
   abstract clickHandler(): void;
 
@@ -117,7 +117,7 @@ export default abstract class Draggable extends Component {
     }
 
     if (dropTarget) {
-      this.dropSwapHanlder(dropTarget);
+      this.dropSwapHandler(dropTarget);
     }
   }
 

--- a/src/shared/Draggable.ts
+++ b/src/shared/Draggable.ts
@@ -1,6 +1,6 @@
 import Component from "./Component";
 
-const DRAG_THRESHOLD = 2;
+const DRAG_THRESHOLD = 10;
 
 export default abstract class Draggable extends Component {
   private clientX: number = 0;


### PR DESCRIPTION
## What Was Done
Fixed the flickering of card backgrounds during state updates.

## Reason for the Change
Previously, during state updates, all cells inside a row were recreated. The behavior of the rows was changed to only update the cells that had corresponding content changes. In the process, another issue was inadvertently resolved.

Closes #80  
Closes #103  

## Implementation Details
Rows are now subscribed directly to the state, rather than being subscribed from within the field. A couple of child classes were created for different types of rows, as the updating logic varies significantly between them.
