### PR TITLE
fix: PZ-105 Debounce the resize handler

### DIFF
--- a/src/features/game/card/WordCard.module.css
+++ b/src/features/game/card/WordCard.module.css
@@ -18,7 +18,9 @@
   user-select: none;
 
   & * {
-    transition: background-color 0.3s;
+    transition:
+      background-color 0.3s,
+      background-position 0.3s;
   }
 }
 

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -22,6 +22,8 @@ export default abstract class Row extends Component implements Observer {
 
   protected roundId: string = "";
 
+  boundResizeHandler: EventListener;
+
   constructor(
     protected type: RowType,
     public stageNumber: number,
@@ -37,10 +39,12 @@ export default abstract class Row extends Component implements Observer {
 
     this.configure();
 
-    window.addEventListener(
-      "resize",
-      debounceListener(this.updateBackgroundPositions.bind(this), 200),
+    this.boundResizeHandler = debounceListener(
+      this.updateBackgroundPositions.bind(this),
+      200,
     );
+
+    window.addEventListener("resize", this.boundResizeHandler);
   }
 
   configure() {
@@ -143,6 +147,7 @@ export default abstract class Row extends Component implements Observer {
   deleteRow() {
     this.roundState.unsubscribe(this);
     this.hintSettings.unsubscribe(this);
+    window.removeEventListener("resize", this.boundResizeHandler);
 
     this.destroy();
   }

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -1,4 +1,5 @@
 import Component from "../../../shared/Component";
+import { debounceListener } from "../../../shared/helpers";
 import { Observer, Publisher } from "../../../shared/Observer";
 import { div } from "../../../ui/tags";
 import WordCard from "../card/WordCard";
@@ -38,7 +39,7 @@ export default abstract class Row extends Component implements Observer {
 
     window.addEventListener(
       "resize",
-      this.updateBackgroundPositions.bind(this),
+      debounceListener(this.updateBackgroundPositions.bind(this), 200),
     );
   }
 

--- a/src/features/game/fields/WordsPicker.ts
+++ b/src/features/game/fields/WordsPicker.ts
@@ -6,7 +6,10 @@ import HintSettings from "../model/HintSettings";
 
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { calculateImageAspectRatio } from "../../../shared/helpers";
+import {
+  calculateImageAspectRatio,
+  debounceListener,
+} from "../../../shared/helpers";
 
 import styles from "./WordsPicker.module.css";
 
@@ -28,7 +31,10 @@ export default class WordsPicker extends Component implements Observer {
 
     roundState.subscribe(this);
 
-    window.addEventListener("resize", this.handleResize.bind(this));
+    window.addEventListener(
+      "resize",
+      debounceListener(this.handleResize.bind(this), 200),
+    );
   }
 
   async update(publisher: Publisher) {

--- a/src/features/game/fields/WordsPicker.ts
+++ b/src/features/game/fields/WordsPicker.ts
@@ -20,6 +20,8 @@ export default class WordsPicker extends Component implements Observer {
 
   private imageAspectRatio: number = 0;
 
+  private boundResizeHandler: EventListener;
+
   constructor(
     private roundState: RoundState,
     private hintSettings: HintSettings,
@@ -31,10 +33,12 @@ export default class WordsPicker extends Component implements Observer {
 
     roundState.subscribe(this);
 
-    window.addEventListener(
-      "resize",
-      debounceListener(this.handleResize.bind(this), 200),
+    this.boundResizeHandler = debounceListener(
+      this.handleResize.bind(this),
+      200,
     );
+
+    window.addEventListener("resize", this.boundResizeHandler);
   }
 
   async update(publisher: Publisher) {
@@ -88,5 +92,12 @@ export default class WordsPicker extends Component implements Observer {
     row.updateCells(this.roundState.state.content.pickArea);
 
     return row;
+  }
+
+  destroy() {
+    this.clear();
+
+    window.removeEventListener("resize", this.boundResizeHandler);
+    this.element.remove();
   }
 }

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -132,3 +132,20 @@ export function prepareRound(difficulty: number, round: number): Round {
     },
   };
 }
+
+export function debounceListener<T extends EventListener>(
+  handler: T,
+  wait: number = 200,
+) {
+  let timeout: ReturnType<typeof setTimeout>;
+
+  return function debounced(
+    this: ThisParameterType<T>,
+    ...args: Parameters<T>
+  ) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      handler.apply(this, args);
+    }, wait);
+  };
+}


### PR DESCRIPTION
## What Was Done
Resolved the issue with background positions not updating during window resizing.

## Reason for the Change
The background position for the word cards did not update correctly during screen rotation. While it did update in general, the gradual changes in window size made the issue less noticeable. However, on mobile devices, the sudden change in size highlighted the problem.

## Implementation Details
A debounce decorator was implemented to address this issue.