### PR TITLE
refactor: PZ-107 Place type definitions into correcponign files

### DIFF
--- a/src/features/game/card/PaintingInfo.ts
+++ b/src/features/game/card/PaintingInfo.ts
@@ -1,8 +1,7 @@
 import Component from "../../../shared/Component";
 import { Observer, Publisher } from "../../../shared/Observer";
 import { p } from "../../../ui/tags";
-import RoundState from "../model/RoundState";
-import { Painting } from "../types";
+import RoundState, { type Painting } from "../model/RoundState";
 
 import styles from "./PaintingInfo.module.css";
 

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -5,8 +5,8 @@ import { div, span } from "../../../ui/tags";
 import RoundState, { type MoveCardAction } from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
-import type { RowData } from "../fields/Row";
-import { RowType } from "../enums";
+import { type RowData } from "../fields/Row";
+import { RowType } from "../fields/RowType";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -6,11 +6,21 @@ import RoundState, { type MoveCardAction } from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
 import type { RowData } from "../fields/Row";
-import { Word, RowType } from "../types";
+import { RowType } from "../types";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";
 import rowStyles from "../fields/Row.module.css";
+
+export interface Word {
+  readonly correctPosition: number;
+  text: string;
+  width: number;
+  isLast: boolean;
+  offset: number;
+  stage: number;
+  image: string;
+}
 
 export default class WordCard extends Draggable {
   private textSpan: Component;

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -6,7 +6,7 @@ import RoundState, { type MoveCardAction } from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
 import type { RowData } from "../fields/Row";
-import { RowType } from "../types";
+import { RowType } from "../enums";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";

--- a/src/features/game/card/WordCard.ts
+++ b/src/features/game/card/WordCard.ts
@@ -2,10 +2,11 @@ import Component from "../../../shared/Component";
 import Draggable from "../../../shared/Draggable";
 import { div, span } from "../../../ui/tags";
 
+import RoundState, { type MoveCardAction } from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
-import RoundState from "../model/RoundState";
+
 import type { RowData } from "../fields/Row";
-import { Word, MoveCardAction, RowType } from "../types";
+import { Word, RowType } from "../types";
 import { assertNonNull, IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./WordCard.module.css";

--- a/src/features/game/enums.ts
+++ b/src/features/game/enums.ts
@@ -1,3 +1,5 @@
+// enums are places in separate file to avoid dependency cycles
+
 export enum RowType {
   PICK = "pickArea",
   ASSEMBLE = "assembleArea",

--- a/src/features/game/enums.ts
+++ b/src/features/game/enums.ts
@@ -1,13 +1,15 @@
-// enums are places in separate file to avoid dependency cycles
+export const StageStatus = {
+  NOT_COMPLETED: "notCompleted",
+  CORRECT: "correct",
+  INCORRECT: "incorrect",
+  AUTOCOMPLETED: "autocompleted",
+} as const;
 
-export enum RowType {
-  PICK = "pickArea",
-  ASSEMBLE = "assembleArea",
-}
+export type StageStatus = (typeof StageStatus)[keyof typeof StageStatus];
 
-export enum StageStatus {
-  NOT_COMPLETED = "notCompleted",
-  CORRECT = "correct",
-  INCORRECT = "incorrect",
-  AUTOCOMPLETED = "autocompleted",
-}
+export const RowType = {
+  PICK: "pickArea",
+  ASSEMBLE: "assembleArea",
+} as const;
+
+export type RowType = (typeof RowType)[keyof typeof RowType];

--- a/src/features/game/fields/AssembleRow.ts
+++ b/src/features/game/fields/AssembleRow.ts
@@ -3,7 +3,7 @@ import RoundState from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
 import { Publisher } from "../../../shared/Observer";
-import { RowType, StageStatus } from "../types";
+import { RowType, StageStatus } from "../enums";
 
 import styles from "./Row.module.css";
 

--- a/src/features/game/fields/AssembleRow.ts
+++ b/src/features/game/fields/AssembleRow.ts
@@ -49,7 +49,10 @@ export default class AssembleRow extends Row {
 
     if (status !== StageStatus.NOT_COMPLETED) this.addClass(styles[status]);
 
-    if ([StageStatus.CORRECT, StageStatus.AUTOCOMPLETED].includes(status)) {
+    if (
+      StageStatus.CORRECT === status ||
+      StageStatus.AUTOCOMPLETED === status
+    ) {
       this.toggleRowBackgrounds(true);
 
       // solved rows always display background, so the row doesn't have to be affected by hint settings anymore

--- a/src/features/game/fields/AssembleRow.ts
+++ b/src/features/game/fields/AssembleRow.ts
@@ -1,9 +1,10 @@
 import Row from "./Row";
+import { RowType } from "./RowType";
 import RoundState from "../model/RoundState";
 import HintSettings from "../model/HintSettings";
 
 import { Publisher } from "../../../shared/Observer";
-import { RowType, StageStatus } from "../enums";
+import { StageStatus } from "../model/StageStatus";
 
 import styles from "./Row.module.css";
 

--- a/src/features/game/fields/PickRow.ts
+++ b/src/features/game/fields/PickRow.ts
@@ -2,7 +2,7 @@ import { Publisher } from "../../../shared/Observer";
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
 import Row from "./Row";
-import { RowType } from "../enums";
+import { RowType } from "./RowType";
 
 export default class PickRow extends Row {
   constructor(

--- a/src/features/game/fields/PickRow.ts
+++ b/src/features/game/fields/PickRow.ts
@@ -1,8 +1,8 @@
 import { Publisher } from "../../../shared/Observer";
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
-import { RowType } from "../types";
 import Row from "./Row";
+import { RowType } from "../enums";
 
 export default class PickRow extends Row {
   constructor(

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -4,12 +4,12 @@ import { Observer, Publisher } from "../../../shared/Observer";
 import { div } from "../../../ui/tags";
 
 import WordCard, { type Word } from "../card/WordCard";
-import { RowType } from "../enums";
 
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
 
 import styles from "./Row.module.css";
+import { RowType } from "./RowType";
 
 export interface RowData {
   type: RowType;

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -2,10 +2,10 @@ import Component from "../../../shared/Component";
 import { debounceListener } from "../../../shared/helpers";
 import { Observer, Publisher } from "../../../shared/Observer";
 import { div } from "../../../ui/tags";
-import WordCard from "../card/WordCard";
+import WordCard, { type Word } from "../card/WordCard";
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
-import { RowType, Word } from "../types";
+import { RowType } from "../types";
 
 import styles from "./Row.module.css";
 

--- a/src/features/game/fields/Row.ts
+++ b/src/features/game/fields/Row.ts
@@ -2,10 +2,12 @@ import Component from "../../../shared/Component";
 import { debounceListener } from "../../../shared/helpers";
 import { Observer, Publisher } from "../../../shared/Observer";
 import { div } from "../../../ui/tags";
+
 import WordCard, { type Word } from "../card/WordCard";
+import { RowType } from "../enums";
+
 import HintSettings from "../model/HintSettings";
 import RoundState from "../model/RoundState";
-import { RowType } from "../types";
 
 import styles from "./Row.module.css";
 

--- a/src/features/game/fields/RowType.ts
+++ b/src/features/game/fields/RowType.ts
@@ -1,0 +1,6 @@
+export const RowType = {
+  PICK: "pickArea",
+  ASSEMBLE: "assembleArea",
+} as const;
+
+export type RowType = (typeof RowType)[keyof typeof RowType];

--- a/src/features/game/hints/HintControls.ts
+++ b/src/features/game/hints/HintControls.ts
@@ -1,6 +1,5 @@
 import Component from "../../../shared/Component";
-import HintSettings from "../model/HintSettings";
-import { HintSettingsData } from "../types";
+import HintSettings, { HintSettingsData } from "../model/HintSettings";
 
 import { Observer, Publisher } from "../../../shared/Observer";
 import { i, input, label } from "../../../ui/tags";

--- a/src/features/game/model/HintSettings.ts
+++ b/src/features/game/model/HintSettings.ts
@@ -1,5 +1,10 @@
 import State from "../../../app/state/StatePublisher";
-import { HintSettingsData } from "../types";
+
+export interface HintSettingsData {
+  translation: boolean;
+  audio: boolean;
+  background: boolean;
+}
 
 const defaultState: HintSettingsData = {
   translation: true,

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,12 +2,19 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { GameContent, Painting, RowType, Stage, StageStatus } from "../types";
+import { GameContent, RowType, Stage, StageStatus } from "../types";
 import {
   generateStageWords,
   prepareRound,
   RATING_THRESHOLDS,
 } from "../../../shared/helpers";
+
+export interface Painting {
+  author: string;
+  name: string;
+  imageSrc: string;
+  year: string;
+}
 
 export interface Round {
   id: string;

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,7 +2,8 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { RowType, StageStatus } from "../enums";
+import { StageStatus } from "./StageStatus";
+import { type RowType } from "../fields/RowType";
 import { type Word } from "../card/WordCard";
 import {
   generateStageWords,

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,7 +2,7 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { RowType, StageStatus } from "../types";
+import { RowType, StageStatus } from "../enums";
 import { type Word } from "../card/WordCard";
 import {
   generateStageWords,

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,12 +2,17 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { GameContent, RowType, Stage, StageStatus } from "../types";
+import { RowType, Stage, StageStatus, Word } from "../types";
 import {
   generateStageWords,
   prepareRound,
   RATING_THRESHOLDS,
 } from "../../../shared/helpers";
+
+export interface GameContent {
+  pickArea: Array<Word | null>;
+  assembleArea: Array<Word | null>;
+}
 
 export interface Painting {
   author: string;

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,7 +2,7 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { RowType, Stage, StageStatus, Word } from "../types";
+import { RowType, StageStatus, Word } from "../types";
 import {
   generateStageWords,
   prepareRound,
@@ -19,6 +19,15 @@ export interface Painting {
   name: string;
   imageSrc: string;
   year: string;
+}
+
+export interface Stage {
+  status: StageStatus;
+  stageNumber: number;
+  sentence: string;
+  sentenceLength: number;
+  translation: string;
+  audio: string;
 }
 
 export interface Round {

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,7 +2,8 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { RowType, StageStatus, Word } from "../types";
+import { RowType, StageStatus } from "../types";
+import { type Word } from "../card/WordCard";
 import {
   generateStageWords,
   prepareRound,

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -1,13 +1,22 @@
 import State from "../../../app/state/StatePublisher";
-import RoundSettings from "./RoundSettings";
+import RoundSettings, { RoundResult } from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { Round, RowType, Stage, StageStatus } from "../types";
+import { GameContent, Painting, RowType, Stage, StageStatus } from "../types";
 import {
   generateStageWords,
   prepareRound,
   RATING_THRESHOLDS,
 } from "../../../shared/helpers";
+
+export interface Round {
+  id: string;
+  currentStage: number;
+  painting: Painting;
+  stages: Array<Stage>;
+  content: GameContent;
+  results: RoundResult;
+}
 
 export interface MoveCardAction {
   type: string;

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -177,8 +177,9 @@ export default class RoundState extends State<Round> implements Observer {
   isStageCompleted(
     stage: Stage = this.state.stages[this.state.currentStage],
   ): boolean {
-    return [StageStatus.AUTOCOMPLETED, StageStatus.CORRECT].includes(
-      stage.status,
+    return (
+      StageStatus.CORRECT === stage.status ||
+      StageStatus.AUTOCOMPLETED === stage.status
     );
   }
 

--- a/src/features/game/model/RoundState.ts
+++ b/src/features/game/model/RoundState.ts
@@ -2,12 +2,22 @@ import State from "../../../app/state/StatePublisher";
 import RoundSettings from "./RoundSettings";
 import { Observer, Publisher } from "../../../shared/Observer";
 
-import { MoveCardAction, Round, Stage, StageStatus } from "../types";
+import { Round, RowType, Stage, StageStatus } from "../types";
 import {
   generateStageWords,
   prepareRound,
   RATING_THRESHOLDS,
 } from "../../../shared/helpers";
+
+export interface MoveCardAction {
+  type: string;
+  payload: {
+    indexFrom: number;
+    rowFrom: RowType;
+    indexTo: number;
+    rowTo: RowType;
+  };
+}
 
 export default class RoundState extends State<Round> implements Observer {
   constructor(private roundSettings: RoundSettings) {

--- a/src/features/game/model/StageStatus.ts
+++ b/src/features/game/model/StageStatus.ts
@@ -1,3 +1,4 @@
+// to avoid dependency cycles
 export const StageStatus = {
   NOT_COMPLETED: "notCompleted",
   CORRECT: "correct",
@@ -6,10 +7,3 @@ export const StageStatus = {
 } as const;
 
 export type StageStatus = (typeof StageStatus)[keyof typeof StageStatus];
-
-export const RowType = {
-  PICK: "pickArea",
-  ASSEMBLE: "assembleArea",
-} as const;
-
-export type RowType = (typeof RowType)[keyof typeof RowType];

--- a/src/features/game/stats/ArtworkMiniature.ts
+++ b/src/features/game/stats/ArtworkMiniature.ts
@@ -1,7 +1,7 @@
 import Component from "../../../shared/Component";
 import { div, img, p } from "../../../ui/tags";
 
-import { Painting } from "../types";
+import { type Painting } from "../model/RoundState";
 import { IMAGES_BASE_URL } from "../../../shared/helpers";
 
 import styles from "./ArtworkMiniature.module.css";

--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -7,7 +7,7 @@ import { div, i } from "../../../ui/tags";
 
 import RoundState, { type Stage } from "../model/RoundState";
 import { Observer, Publisher } from "../../../shared/Observer";
-import { StageStatus } from "../enums";
+import { StageStatus } from "../model/StageStatus";
 
 import styles from "./RoundStats.module.css";
 

--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -7,7 +7,7 @@ import { div, i } from "../../../ui/tags";
 
 import RoundState, { type Stage } from "../model/RoundState";
 import { Observer, Publisher } from "../../../shared/Observer";
-import { StageStatus } from "../types";
+import { StageStatus } from "../enums";
 
 import styles from "./RoundStats.module.css";
 

--- a/src/features/game/stats/RoundStats.ts
+++ b/src/features/game/stats/RoundStats.ts
@@ -5,9 +5,9 @@ import SentencesList, { SentencesListType } from "./SentencesList";
 import Button from "../../../ui/button/Button";
 import { div, i } from "../../../ui/tags";
 
-import RoundState from "../model/RoundState";
+import RoundState, { type Stage } from "../model/RoundState";
 import { Observer, Publisher } from "../../../shared/Observer";
-import { Stage, StageStatus } from "../types";
+import { StageStatus } from "../types";
 
 import styles from "./RoundStats.module.css";
 

--- a/src/features/game/stats/SentencesList.ts
+++ b/src/features/game/stats/SentencesList.ts
@@ -1,7 +1,7 @@
 import Component from "../../../shared/Component";
 import AudioButton from "../../../ui/button/AudioButton";
 import { h3, li, p, span, ul } from "../../../ui/tags";
-import { Stage } from "../types";
+import { type Stage } from "../model/RoundState";
 
 import styles from "./SentencesList.module.css";
 

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -1,15 +1,5 @@
 import { RoundResult } from "./model/RoundSettings";
 
-export interface MoveCardAction {
-  type: string;
-  payload: {
-    indexFrom: number;
-    rowFrom: RowType;
-    indexTo: number;
-    rowTo: RowType;
-  };
-}
-
 export enum RowType {
   PICK = "pickArea",
   ASSEMBLE = "assembleArea",

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -33,10 +33,3 @@ export interface GameContent {
   pickArea: Array<Word | null>;
   assembleArea: Array<Word | null>;
 }
-
-export interface Painting {
-  author: string;
-  name: string;
-  imageSrc: string;
-  year: string;
-}

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -19,12 +19,3 @@ export interface Word {
   stage: number;
   image: string;
 }
-
-export interface Stage {
-  status: StageStatus;
-  stageNumber: number;
-  sentence: string;
-  sentenceLength: number;
-  translation: string;
-  audio: string;
-}

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -1,5 +1,3 @@
-import { RoundResult } from "./model/RoundSettings";
-
 export enum RowType {
   PICK = "pickArea",
   ASSEMBLE = "assembleArea",
@@ -41,13 +39,4 @@ export interface Painting {
   name: string;
   imageSrc: string;
   year: string;
-}
-
-export interface Round {
-  id: string;
-  currentStage: number;
-  painting: Painting;
-  stages: Array<Stage>;
-  content: GameContent;
-  results: RoundResult;
 }

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -5,12 +5,6 @@ export enum RowType {
   ASSEMBLE = "assembleArea",
 }
 
-export interface HintSettingsData {
-  translation: boolean;
-  audio: boolean;
-  background: boolean;
-}
-
 export enum StageStatus {
   NOT_COMPLETED = "notCompleted",
   CORRECT = "correct",

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -28,8 +28,3 @@ export interface Stage {
   translation: string;
   audio: string;
 }
-
-export interface GameContent {
-  pickArea: Array<Word | null>;
-  assembleArea: Array<Word | null>;
-}

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -9,13 +9,3 @@ export enum StageStatus {
   INCORRECT = "incorrect",
   AUTOCOMPLETED = "autocompleted",
 }
-
-export interface Word {
-  readonly correctPosition: number;
-  text: string;
-  width: number;
-  isLast: boolean;
-  offset: number;
-  stage: number;
-  image: string;
-}

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,6 +1,7 @@
 import Component from "./Component";
 import LEVELS from "../../data/levels";
-import { StageStatus, Word } from "../features/game/types";
+import { StageStatus } from "../features/game/types";
+import { type Word } from "../features/game/card/WordCard";
 import { type Round, type Stage } from "../features/game/model/RoundState";
 
 export const IMAGES_BASE_URL =

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,6 +1,6 @@
 import Component from "./Component";
 import LEVELS from "../../data/levels";
-import { StageStatus } from "../features/game/types";
+import { StageStatus } from "../features/game/enums";
 import { type Word } from "../features/game/card/WordCard";
 import { type Round, type Stage } from "../features/game/model/RoundState";
 

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,7 +1,7 @@
 import Component from "./Component";
 import LEVELS from "../../data/levels";
-import { Stage, StageStatus, Word } from "../features/game/types";
-import { type Round } from "../features/game/model/RoundState";
+import { StageStatus, Word } from "../features/game/types";
+import { type Round, type Stage } from "../features/game/model/RoundState";
 
 export const IMAGES_BASE_URL =
   "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,6 +1,7 @@
 import Component from "./Component";
 import LEVELS from "../../data/levels";
-import { Round, Stage, StageStatus, Word } from "../features/game/types";
+import { Stage, StageStatus, Word } from "../features/game/types";
+import { type Round } from "../features/game/model/RoundState";
 
 export const IMAGES_BASE_URL =
   "https://raw.githubusercontent.com/rolling-scopes-school/rss-puzzle-data/main/images";

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,6 +1,6 @@
 import Component from "./Component";
 import LEVELS from "../../data/levels";
-import { StageStatus } from "../features/game/enums";
+import { StageStatus } from "../features/game/model/StageStatus";
 import { type Word } from "../features/game/card/WordCard";
 import { type Round, type Stage } from "../features/game/model/RoundState";
 


### PR DESCRIPTION
## What Was Done
I moved type definitions from `types.ts` to their corresponding component files. Additionally, I decided not to use enums.

## Reason for the Change
Bringing type definitions closer to their respective components reduces confusion. As for enums, they are not well-transpiled to JavaScript and lack type safety.

## Implementation Details
I replaced enums with union types.